### PR TITLE
Add joint_offsets to ar_gazebo file

### DIFF
--- a/ar_description/urdf/ar_gazebo.urdf.xacro
+++ b/ar_description/urdf/ar_gazebo.urdf.xacro
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="$(arg name)">
-  <xacro:include filename="$(find ar_description)/urdf/ar_macro.xacro"/>
-  <xacro:include filename="$(find ar_description)/urdf/ar_gripper_macro.xacro"/>
-  <xacro:include filename="$(find ar_description)/urdf/ar.ros2_control.xacro"/>
-  <xacro:include filename="$(find ar_description)/urdf/ar_gripper.ros2_control.xacro"/>
+  <xacro:include filename="$(find ar_description)/urdf/ar_macro.xacro" />
+  <xacro:include filename="$(find ar_description)/urdf/ar_gripper_macro.xacro" />
+  <xacro:include filename="$(find ar_description)/urdf/ar.ros2_control.xacro" />
+  <xacro:include filename="$(find ar_description)/urdf/ar_gripper.ros2_control.xacro" />
 
   <xacro:arg name="simulation_controllers" default="" />
 
@@ -18,6 +18,7 @@
     plugin_name="gazebo_ros2_control/GazeboSystem"
     serial_port="None"
     calibrate="False"
+    joint_offset_parameters_file="$(find ar_hardware_interface)/config/joint_offsets.yaml"
   />
 
   <xacro:ar_gripper_ros2_control


### PR DESCRIPTION
I noticed that ar_gazebo won't launch after the recent inclusion of the `joint_offsets.yaml` file.

Looks like my editor auto-formatted the file as well. Hope that's OK.