### PR TITLE
read j4 and j6 limits from config in ar.ros2_control.xacro

### DIFF
--- a/ar_description/urdf/ar.ros2_control.xacro
+++ b/ar_description/urdf/ar.ros2_control.xacro
@@ -6,8 +6,12 @@
     plugin_name
     serial_port
     calibrate
+    robot_parameters_file
     joint_offset_parameters_file
   ">
+
+    <xacro:property name="robot_parameters"
+      value="${xacro.load_yaml(robot_parameters_file)}"/>
 
     <xacro:property name="joint_offset_parameters"
       value="${xacro.load_yaml(joint_offset_parameters_file)}"/>
@@ -55,8 +59,8 @@
 
       <joint name="joint_4">
         <command_interface name="position">
-          <param name="min">{-165*pi/180}</param>
-          <param name="max">{165*pi/180}</param>
+          <param name="min">${-robot_parameters['j4_limit']}</param>
+          <param name="max">${robot_parameters['j4_limit']}</param>
         </command_interface>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -77,8 +81,8 @@
 
       <joint name="joint_6">
         <command_interface name="position">
-          <param name="min">{-155*pi/180}</param>
-          <param name="max">{155*pi/180}</param>
+          <param name="min">${-robot_parameters['j4_limit']}</param>
+          <param name="max">${robot_parameters['j6_limit']}</param>
         </command_interface>
         <state_interface name="position">
           <param name="initial_value">0.0</param>

--- a/ar_description/urdf/ar_gazebo.urdf.xacro
+++ b/ar_description/urdf/ar_gazebo.urdf.xacro
@@ -21,6 +21,7 @@
     plugin_name="gazebo_ros2_control/GazeboSystem"
     serial_port="None"
     calibrate="False"
+    robot_parameters_file="$(find ar_description)/config/$(arg ar_model).yaml"
     joint_offset_parameters_file="$(find ar_hardware_interface)/config/joint_offsets/$(arg ar_model).yaml"
   />
 

--- a/ar_hardware_interface/urdf/ar.urdf.xacro
+++ b/ar_hardware_interface/urdf/ar.urdf.xacro
@@ -20,6 +20,7 @@
     plugin_name="ar_hardware_interface/ARHardwareInterface"
     serial_port="$(arg serial_port)"
     calibrate="$(arg calibrate)"
+    robot_parameters_file="$(find ar_description)/config/$(arg ar_model).yaml"
     joint_offset_parameters_file="$(find ar_hardware_interface)/config/joint_offsets/$(arg ar_model).yaml"
   />
 

--- a/ar_moveit_config/urdf/fake_ar.urdf.xacro
+++ b/ar_moveit_config/urdf/fake_ar.urdf.xacro
@@ -19,6 +19,7 @@
     plugin_name="mock_components/GenericSystem"
     serial_port="/dev/ttyACM0"
     calibrate="False"
+    robot_parameters_file="$(find ar_description)/config/$(arg ar_model).yaml"
     joint_offset_parameters_file="$(find ar_hardware_interface)/config/joint_offsets/$(arg ar_model).yaml"
   />
   <xacro:ar_gripper_ros2_control


### PR DESCRIPTION
Previously joint limits were hard coded to AR4 MK1's values in ar.ros2_control.xacro, but MK3 has different limits. This PR reads joint limits from config files, so that they can be different for MK3.