### PR TITLE
calibration can return error and timeout

### DIFF
--- a/ar_hardware_interface/include/ar_hardware_interface/teensy_driver.hpp
+++ b/ar_hardware_interface/include/ar_hardware_interface/teensy_driver.hpp
@@ -44,7 +44,7 @@ class TeensyDriver {
   void checkInit(std::string msg);
   void updateEncoderCalibrations(std::string msg);
   void updateJointPositions(std::string msg);
-  bool hasError(std::string msg);
+  bool succeeded(std::string msg);
 };
 
 }  // namespace ar_hardware_interface

--- a/ar_hardware_interface/include/ar_hardware_interface/teensy_driver.hpp
+++ b/ar_hardware_interface/include/ar_hardware_interface/teensy_driver.hpp
@@ -20,7 +20,7 @@ class TeensyDriver {
   void update(std::vector<double>& pos_commands,
               std::vector<double>& joint_states);
   void getJointPositions(std::vector<double>& joint_positions);
-  void calibrateJoints();
+  bool calibrateJoints();
 
   TeensyDriver();
 
@@ -36,7 +36,7 @@ class TeensyDriver {
   rclcpp::Clock clock_ = rclcpp::Clock(RCL_ROS_TIME);
 
   // Comms with teensy
-  void exchange(std::string outMsg);  // exchange joint commands/state
+  bool exchange(std::string outMsg);  // exchange joint commands/state
   bool transmit(std::string outMsg, std::string& err);
   void receive(std::string& inMsg);
   bool sendCommand(std::string outMsg);  // send arbitrary commands

--- a/ar_hardware_interface/include/ar_hardware_interface/teensy_driver.hpp
+++ b/ar_hardware_interface/include/ar_hardware_interface/teensy_driver.hpp
@@ -39,11 +39,12 @@ class TeensyDriver {
   void exchange(std::string outMsg);  // exchange joint commands/state
   bool transmit(std::string outMsg, std::string& err);
   void receive(std::string& inMsg);
-  void sendCommand(std::string outMsg);  // send arbitrary commands
+  bool sendCommand(std::string outMsg);  // send arbitrary commands
 
   void checkInit(std::string msg);
   void updateEncoderCalibrations(std::string msg);
   void updateJointPositions(std::string msg);
+  bool hasError(std::string msg);
 };
 
 }  // namespace ar_hardware_interface

--- a/ar_hardware_interface/src/ar_hardware_interface.cpp
+++ b/ar_hardware_interface/src/ar_hardware_interface.cpp
@@ -50,7 +50,9 @@ hardware_interface::CallbackReturn ARHardwareInterface::on_activate(
   if (calibrate) {
     // run calibration
     RCLCPP_INFO(logger_, "Running joint calibration...");
-    driver_.calibrateJoints();
+    if (!driver_.calibrateJoints()) {
+      return hardware_interface::CallbackReturn::ERROR;
+    }
   }
 
   // init position commands at current positions

--- a/ar_hardware_interface/src/teensy_driver.cpp
+++ b/ar_hardware_interface/src/teensy_driver.cpp
@@ -77,9 +77,9 @@ void TeensyDriver::update(std::vector<double>& pos_commands,
   joint_positions = joint_positions_deg_;
 }
 
-void TeensyDriver::calibrateJoints() {
+bool TeensyDriver::calibrateJoints() {
   std::string outMsg = "JC\n";
-  sendCommand(outMsg);
+  return sendCommand(outMsg);
 }
 
 void TeensyDriver::getJointPositions(std::vector<double>& joint_positions) {
@@ -90,44 +90,41 @@ void TeensyDriver::getJointPositions(std::vector<double>& joint_positions) {
 }
 
 // Send specific commands
-void TeensyDriver::sendCommand(std::string outMsg) { exchange(outMsg); }
+bool TeensyDriver::sendCommand(std::string outMsg) { return exchange(outMsg); }
 
 // Send msg to board and collect data
-void TeensyDriver::exchange(std::string outMsg) {
+bool TeensyDriver::exchange(std::string outMsg) {
   std::string inMsg;
   std::string errTransmit = "";
 
   if (!transmit(outMsg, errTransmit)) {
     RCLCPP_ERROR(logger_, "Error in transmit: %s", errTransmit.c_str());
+    return false;
   }
 
-  bool done = false;
-  while (!done) {
-    receive(inMsg);
-    // parse msg
-    std::string header = inMsg.substr(0, 2);
-    if (header == "ST") {
-      // init acknowledgement
-      checkInit(inMsg);
-      done = true;
-    } else if (header == "JC") {
-      // encoder calibration values
-      updateEncoderCalibrations(inMsg);
-      done = true;
-    } else if (header == "JP") {
-      // encoder steps
-      updateJointPositions(inMsg);
-      done = true;
-    } else if (header == "DB") {
-      // debug message
-      RCLCPP_DEBUG(logger_, "Debug message: %s", inMsg.c_str());
-      done = true;
-    } else {
-      // unknown header
-      RCLCPP_WARN(logger_, "Unknown header %s", header.c_str());
-      done = true;
+  receive(inMsg);
+  // parse msg
+  std::string header = inMsg.substr(0, 2);
+  if (header == "ST") {
+    // init acknowledgement
+    checkInit(inMsg);
+  } else if (header == "JC") {
+    if (hasError(inMsg)) {
+      return false;
     }
+    // encoder calibration values
+    updateEncoderCalibrations(inMsg);
+  } else if (header == "JP") {
+    // encoder steps
+    updateJointPositions(inMsg);
+  } else if (header == "DB") {
+    // debug message
+    RCLCPP_DEBUG(logger_, "Debug message: %s", inMsg.c_str());
+  } else {
+    // unknown header
+    RCLCPP_WARN(logger_, "Unknown header %s", header.c_str());
   }
+  return true;
 }
 
 bool TeensyDriver::transmit(std::string msg, std::string& err) {
@@ -206,6 +203,16 @@ void TeensyDriver::updateJointPositions(std::string msg) {
   joint_positions_deg_[3] = std::stod(msg.substr(idx4, idx5 - idx4));
   joint_positions_deg_[4] = std::stod(msg.substr(idx5, idx6 - idx5));
   joint_positions_deg_[5] = std::stod(msg.substr(idx6));
+}
+
+bool TeensyDriver::hasError(std::string msg) {
+  const std::string errmsg_code = "ERRMSG:";
+  idx = msg.find(errmsg_code, 2);
+  if (idx != std::string::npos) {
+    RCLCPP_ERROR(logger_, "Error message received: %s", msg.substr(idx+errmsg_code.size()).c_str());
+    return false;
+  }
+  return true;
 }
 
 }  // namespace ar_hardware_interface

--- a/ar_hardware_interface/src/teensy_driver.cpp
+++ b/ar_hardware_interface/src/teensy_driver.cpp
@@ -207,12 +207,13 @@ void TeensyDriver::updateJointPositions(std::string msg) {
 
 bool TeensyDriver::hasError(std::string msg) {
   const std::string errmsg_code = "ERRMSG:";
-  idx = msg.find(errmsg_code, 2);
+  size_t idx = msg.find(errmsg_code, 2);
   if (idx != std::string::npos) {
-    RCLCPP_ERROR(logger_, "Error message received: %s", msg.substr(idx+errmsg_code.size()).c_str());
-    return false;
+    RCLCPP_ERROR(logger_, "Error message received: %s",
+                 msg.substr(idx + errmsg_code.size()).c_str());
+    return true;
   }
-  return true;
+  return false;
 }
 
 }  // namespace ar_hardware_interface

--- a/ar_hardware_interface/src/teensy_driver.cpp
+++ b/ar_hardware_interface/src/teensy_driver.cpp
@@ -173,7 +173,7 @@ void TeensyDriver::checkInit(std::string msg) {
 }
 
 void TeensyDriver::updateEncoderCalibrations(std::string msg) {
-  // Skip the first 6 letters as they are the header: JCRES
+  // Skip the first 5 letters as they are the header: JCRES
   size_t idx1 = msg.find("A", 5) + 1;
   size_t idx2 = msg.find("B", 5) + 1;
   size_t idx3 = msg.find("C", 5) + 1;

--- a/ar_microcontrollers/AR4/AR4.ino
+++ b/ar_microcontrollers/AR4/AR4.ino
@@ -176,7 +176,7 @@ bool calibrateJoints(int* calJoints) {
       }
     }
 
-    if (millis() - startTime > 5000) {
+    if (millis() - startTime > 20000) {
       return false;
     }
   }

--- a/ar_microcontrollers/AR4/AR4.ino
+++ b/ar_microcontrollers/AR4/AR4.ino
@@ -156,7 +156,6 @@ bool calibrateJoints(int* calJoints) {
   for (int i = 0; i < NUM_JOINTS; i++) {
     stepperJoints[i].setSpeed(CAL_SPEED * CAL_SPEED_MULT[i] * CAL_DIR[i]);
   }
-  // make start time the current time
   unsigned long startTime = millis();
   while (!calAllDone) {
     calAllDone = true;
@@ -291,6 +290,7 @@ void stateTRAJ() {
             stepperJoints[i].run();
           }
         }
+
       } else if (function == "JC") {
         // calibrate all joints
         int calJoints[] = {1, 1, 1, 1, 1, 1};

--- a/ar_microcontrollers/AR4/AR4.ino
+++ b/ar_microcontrollers/AR4/AR4.ino
@@ -300,7 +300,7 @@ void stateTRAJ() {
           for (int i = 0; i < NUM_JOINTS; ++i) {
             stepperJoints[i].setSpeed(0);
           }
-          String msg = String("JC") + "ERRMSG:" + "Failed to calibrate joints";
+          String msg = String("JCRES0MSG") + "Failed to calibrate joints.";
           Serial.println(msg);
           continue;
         }
@@ -351,12 +351,12 @@ void stateTRAJ() {
             stepperJoints[i].setSpeed(0);
           }
           String msg =
-              String("JC") + "ERRMSG:" + "Failed to return to rest position";
+              String("JCRES0MSG") + "Failed to return to rest position.";
           continue;
         }
 
         // calibration done, send calibration values
-        String msg = String("JC") + "A" + calSteps[0] + "B" + calSteps[1] +
+        String msg = String("JCRES1") + "A" + calSteps[0] + "B" + calSteps[1] +
                      "C" + calSteps[2] + "D" + calSteps[3] + "E" + calSteps[4] +
                      "F" + calSteps[5];
         Serial.println(msg);

--- a/ar_microcontrollers/AR4_MK2/AR4_MK2.ino
+++ b/ar_microcontrollers/AR4_MK2/AR4_MK2.ino
@@ -147,7 +147,7 @@ void updateStepperSpeed(String inData) {
   JOINT_MAX_ACCEL[5] = inData.substring(idxAccelJ6 + 1).toFloat();
 }
 
-void calibrateJoints(int* calJoints) {
+bool calibrateJoints(int* calJoints) {
   // check which joints to calibrate
   bool calAllDone = false;
   bool calJointsDone[NUM_JOINTS];
@@ -159,6 +159,7 @@ void calibrateJoints(int* calJoints) {
   for (int i = 0; i < NUM_JOINTS; i++) {
     stepperJoints[i].setSpeed(CAL_SPEED * CAL_SPEED_MULT[i] * CAL_DIR[i]);
   }
+  unsigned long startTime = millis();
   while (!calAllDone) {
     calAllDone = true;
     for (int i = 0; i < NUM_JOINTS; ++i) {
@@ -176,10 +177,13 @@ void calibrateJoints(int* calJoints) {
         }
       }
     }
+
+    if (millis() - startTime > 20000) {
+      return false;
+    }
   }
   delay(2000);
-
-  return;
+  return true;
 }
 
 void moveAwayFromLimitSwitch() {
@@ -289,17 +293,26 @@ void stateTRAJ() {
             stepperJoints[i].run();
           }
         }
+
       } else if (function == "JC") {
         // calibrate all joints
         int calJoints[] = {1, 1, 1, 1, 1, 1};
-        calibrateJoints(calJoints);
+        int success = calibrateJoints(calJoints);
+        if (!success) {
+          // set all speeds to zero
+          for (int i = 0; i < NUM_JOINTS; ++i) {
+            stepperJoints[i].setSpeed(0);
+          }
+          String msg = String("JCRES0MSG") + "Failed to calibrate joints.";
+          Serial.println(msg);
+          continue;
+        }
 
         // record encoder steps
         int calSteps[6];
         for (int i = 0; i < NUM_JOINTS; ++i) {
           calSteps[i] = encPos[i].read();
         }
-
         for (int i = 0; i < NUM_JOINTS; ++i) {
           encPos[i].write(ENC_RANGE_STEPS[i] * ENC_MAX_AT_ANGLE_MIN[i]);
         }
@@ -318,7 +331,8 @@ void stateTRAJ() {
         }
 
         bool restPosReached = false;
-        while (!restPosReached) {
+        unsigned long startTime = millis();
+        while (!restPosReached && millis() - startTime < 10000) {
           restPosReached = true;
           readMotorSteps(curMotorSteps);
 
@@ -334,17 +348,28 @@ void stateTRAJ() {
             }
           }
         }
+        if (!restPosReached) {
+          // set all speeds to zero
+          for (int i = 0; i < NUM_JOINTS; ++i) {
+            stepperJoints[i].setSpeed(0);
+          }
+          String msg =
+              String("JCRES0MSG") + "Failed to return to rest position.";
+          continue;
+        }
 
         // calibration done, send calibration values
-        String msg = String("JC") + "A" + calSteps[0] + "B" + calSteps[1] +
+        String msg = String("JCRES1") + "A" + calSteps[0] + "B" + calSteps[1] +
                      "C" + calSteps[2] + "D" + calSteps[3] + "E" + calSteps[4] +
                      "F" + calSteps[5];
         Serial.println(msg);
+
       } else if (function == "JP") {
         readMotorSteps(curMotorSteps);
         encStepsToJointPos(curMotorSteps, curJointPos);
         String msg = String("JP") + JointPosToString(curJointPos);
         Serial.println(msg);
+
       } else if (function == "SS") {
         updateStepperSpeed(inData);
         // set motor speed and acceleration
@@ -361,14 +386,15 @@ void stateTRAJ() {
         // update host with joint positions
         String msg = String("JP") + JointPosToString(curJointPos);
         Serial.println(msg);
+
       } else if (function == "ST") {
         if (!initStateTraj(inData)) {
           STATE = STATE_ERR;
           return;
         }
       }
-      // clear message
-      inData = "";
+
+      inData = "";  // clear message
     }
     for (int i = 0; i < NUM_JOINTS; ++i) {
       stepperJoints[i].run();

--- a/ar_microcontrollers/AR4_MK3/AR4_MK3.ino
+++ b/ar_microcontrollers/AR4_MK3/AR4_MK3.ino
@@ -177,6 +177,7 @@ bool calibrateJoints(int* calJoints) {
         }
       }
     }
+
     if (millis() - startTime > 20000) {
       return false;
     }
@@ -292,6 +293,7 @@ void stateTRAJ() {
             stepperJoints[i].run();
           }
         }
+
       } else if (function == "JC") {
         // calibrate all joints
         int calJoints[] = {1, 1, 1, 1, 1, 1};
@@ -311,7 +313,6 @@ void stateTRAJ() {
         for (int i = 0; i < NUM_JOINTS; ++i) {
           calSteps[i] = encPos[i].read();
         }
-
         for (int i = 0; i < NUM_JOINTS; ++i) {
           encPos[i].write(ENC_RANGE_STEPS[i] * ENC_MAX_AT_ANGLE_MIN[i]);
         }
@@ -331,7 +332,7 @@ void stateTRAJ() {
 
         bool restPosReached = false;
         unsigned long startTime = millis();
-        while (!restPosReached) {
+        while (!restPosReached && millis() - startTime < 10000) {
           restPosReached = true;
           readMotorSteps(curMotorSteps);
 
@@ -393,7 +394,7 @@ void stateTRAJ() {
         }
       }
 
-      inData = ""; // clear message
+      inData = "";  // clear message
     }
     for (int i = 0; i < NUM_JOINTS; ++i) {
       stepperJoints[i].run();


### PR DESCRIPTION
In the firmware, add timeout to calibration steps that take a while. If a step times out, a failure result and an error message is returned. The ROS driver handles the failure and report error in activating the driver.