### PR TITLE
Updated README.md to correctly represent ar_moveit.launch.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ ros2 launch ar_moveit_config ar_moveit.launch.py
 
 Available Launch Arguments:
 
-- `ar_model`: The model of the AR4. Options are `ar4` (which includes MK2) or `ar4_mk3`. Defaults to `ar4`.
+- `ar_model`: The model of the AR4. Options are `mk1`, `mk2`, or `mk3`. Defaults to `mk1`.
 - `include_gripper`: Whether to include the servo gripper. Defaults to:
   `include_gripper:=True`.
 - `use_sim_time`: Make Moveit use simulation time. Should only be enabled when


### PR DESCRIPTION
I updated the README.md to correctly represent the ar_moveit.launch.py

```
    declared_arguments.append(
        DeclareLaunchArgument("ar_model",
                              default_value="mk1",
                              choices=["mk1", "mk2", "mk3"],
                              description="Model of AR4"))
```
although, to be consistent with the rest of the README.md, maybe the default value should be changed to mk3?