### PR TITLE
Use Velocity-based Position Control and Bounce2 switches by default, add and PILZ planner

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -78,7 +78,9 @@
       "typeindex": "cpp",
       "typeinfo": "cpp",
       "variant": "cpp",
-      "*.ipp": "cpp"
+      "*.ipp": "cpp",
+      "callback": "cpp",
+      "image": "cpp"
     },
     "ros.distro": "iron",
     "C_Cpp.default.includePath": [
@@ -97,5 +99,8 @@
       "build": true,
       "install": true,
       "log": true
-    }
+    },
+    "cSpell.words": [
+      "RCLCPP"
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -183,3 +183,18 @@ You can now plan in RViz and control the simulated arm.
 ### Hand-Eye Calibration
 
 See [ar4_hand_eye_calibration](https://github.com/ycheng517/ar4_hand_eye_calibration)
+
+## Tuning and Tweaks
+
+### Tuning Joint Offsets
+
+If for some reason your robot's joint positions appear misaligned after moving
+to the home position, you can adjust the joint offsets in the
+[joint_offsets/](./ar_hardware_interface/config/joint_offsets/) config folder.
+Select and modify the YAML file corresponding to your AR model to fine-tune the joint positions.
+
+### Switching to Position Control
+
+By default this repo uses velocity-based joint trajectory control. It allows the arm to move a lot faster and the arm movement is also a lot smoother. If for any
+reason you'd like to use the simpler classic position-only control mode, you can
+set `velocity_control_enabled: false` in [driver.yaml](./ar_hardware_interface/config/driver.yaml). Note that you'll need to reduce velocity and acceleration scaling in order for larger motions to succeed.

--- a/ar_description/package.xml
+++ b/ar_description/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
   <name>ar_description</name>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
   <description>
     URDF Description package for Annin Robotics robotic arms
   </description>

--- a/ar_description/urdf/ar.ros2_control.xacro
+++ b/ar_description/urdf/ar.ros2_control.xacro
@@ -8,6 +8,7 @@
     calibrate
     robot_parameters_file
     joint_offset_parameters_file
+    driver_parameters_file
   ">
 
     <xacro:property name="robot_parameters"
@@ -16,6 +17,9 @@
     <xacro:property name="joint_offset_parameters"
       value="${xacro.load_yaml(joint_offset_parameters_file)}"/>
 
+    <xacro:property name="driver_parameters"
+      value="${xacro.load_yaml(driver_parameters_file)}"/>
+
     <ros2_control name="${ar_model}" type="system">
 
       <hardware>
@@ -23,6 +27,7 @@
         <param name="ar_model">${ar_model}</param>
         <param name="serial_port">${serial_port}</param>
         <param name="calibrate">${calibrate}</param>
+        <param name="velocity_control_enabled">${driver_parameters['velocity_control_enabled']}</param>
       </hardware>
 
       <joint name="joint_1">
@@ -30,7 +35,11 @@
           <param name="min">${robot_parameters['j1_limit_min']}</param>
           <param name="max">${robot_parameters['j1_limit_max']}</param>
         </command_interface>
+        <command_interface name="velocity" />
         <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
           <param name="initial_value">0.0</param>
         </state_interface>
         <param name="position_offset">${joint_offset_parameters['joint_1']}</param>
@@ -41,7 +50,11 @@
           <param name="min">${robot_parameters['j2_limit_min']}</param>
           <param name="max">${robot_parameters['j2_limit_max']}</param>
         </command_interface>
+        <command_interface name="velocity" />
         <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
           <param name="initial_value">0.0</param>
         </state_interface>
         <param name="position_offset">${joint_offset_parameters['joint_2']}</param>
@@ -52,7 +65,11 @@
           <param name="min">${robot_parameters['j3_limit_min']}</param>
           <param name="max">${robot_parameters['j3_limit_max']}</param>
         </command_interface>
+        <command_interface name="velocity" />
         <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
           <param name="initial_value">0.0</param>
         </state_interface>
         <param name="position_offset">${joint_offset_parameters['joint_3']}</param>
@@ -63,7 +80,11 @@
           <param name="min">${robot_parameters['j4_limit_min']}</param>
           <param name="max">${robot_parameters['j4_limit_max']}</param>
         </command_interface>
+        <command_interface name="velocity" />
         <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
           <param name="initial_value">0.0</param>
         </state_interface>
         <param name="position_offset">${joint_offset_parameters['joint_4']}</param>
@@ -74,7 +95,11 @@
           <param name="min">${robot_parameters['j5_limit_min']}</param>
           <param name="max">${robot_parameters['j5_limit_max']}</param>
         </command_interface>
+        <command_interface name="velocity" />
         <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
           <param name="initial_value">0.0</param>
         </state_interface>
         <param name="position_offset">${joint_offset_parameters['joint_5']}</param>
@@ -85,7 +110,11 @@
           <param name="min">${robot_parameters['j6_limit_min']}</param>
           <param name="max">${robot_parameters['j6_limit_max']}</param>
         </command_interface>
+        <command_interface name="velocity" />
         <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
           <param name="initial_value">0.0</param>
         </state_interface>
         <param name="position_offset">${joint_offset_parameters['joint_6']}</param>

--- a/ar_description/urdf/ar_gazebo.urdf.xacro
+++ b/ar_description/urdf/ar_gazebo.urdf.xacro
@@ -23,6 +23,7 @@
     calibrate="False"
     robot_parameters_file="$(find ar_description)/config/$(arg ar_model).yaml"
     joint_offset_parameters_file="$(find ar_hardware_interface)/config/joint_offsets/$(arg ar_model).yaml"
+    driver_parameters_file="$(find ar_hardware_interface)/config/driver.yaml"
   />
 
   <xacro:ar_gripper_ros2_control

--- a/ar_description/urdf/ar_macro.xacro
+++ b/ar_description/urdf/ar_macro.xacro
@@ -63,7 +63,12 @@
       <parent link="base_link"/>
       <child link="link_1"/>
       <axis xyz="0 0 1"/>
-      <limit lower="${robot_parameters['j1_limit_min']}" upper="${robot_parameters['j1_limit_max']}" effort="0" velocity="0.5"/>
+      <limit
+        lower="${robot_parameters['j1_limit_min']}"
+        upper="${robot_parameters['j1_limit_max']}"
+        effort="-1"
+        velocity="1.0472"
+      />
     </joint>
     <link name="link_2">
       <inertial>
@@ -92,7 +97,12 @@
       <parent link="link_1"/>
       <child link="link_2"/>
       <axis xyz="0 0 -1"/>
-      <limit lower="${robot_parameters['j2_limit_min']}" upper="${robot_parameters['j2_limit_max']}" effort="0.5" velocity="0.5"/>
+      <limit 
+        lower="${robot_parameters['j2_limit_min']}"
+        upper="${robot_parameters['j2_limit_max']}"
+        effort="-1" 
+        velocity="1.0472"
+      />
     </joint>
     <link name="link_3">
       <inertial>
@@ -121,7 +131,12 @@
       <parent link="link_2"/>
       <child link="link_3"/>
       <axis xyz="0 0 -1"/>
-      <limit lower="${robot_parameters['j3_limit_min']}" upper="${robot_parameters['j3_limit_max']}" effort="0" velocity="0.5"/>
+      <limit
+        lower="${robot_parameters['j3_limit_min']}"
+        upper="${robot_parameters['j3_limit_max']}"
+        effort="-1"
+        velocity="1.0472"
+      />
     </joint>
     <link name="link_4">
       <inertial>
@@ -150,7 +165,12 @@
       <parent link="link_3"/>
       <child link="link_4"/>
       <axis xyz="0 0 -1"/>
-      <limit lower="${robot_parameters['j4_limit_min']}" upper="${robot_parameters['j4_limit_max']}" effort="0" velocity="0.5"/>
+      <limit
+        lower="${robot_parameters['j4_limit_min']}"
+        upper="${robot_parameters['j4_limit_max']}"
+        effort="-1"
+        velocity="1.0472"
+      />
     </joint>
     <link name="link_5">
       <inertial>
@@ -179,7 +199,12 @@
       <parent link="link_4"/>
       <child link="link_5"/>
       <axis xyz="1 0 0"/>
-      <limit lower="${robot_parameters['j5_limit_min']}" upper="${robot_parameters['j5_limit_max']}" effort="0" velocity="1.0"/>
+      <limit
+        lower="${robot_parameters['j5_limit_min']}"
+        upper="${robot_parameters['j5_limit_max']}"
+        effort="-1"
+        velocity="1.0472"
+      />
     </joint>
     <link name="link_6">
       <inertial>
@@ -208,7 +233,12 @@
       <parent link="link_5"/>
       <child link="link_6"/>
       <axis xyz="0 0 1"/>
-      <limit lower="${robot_parameters['j6_limit_min']}" upper="${robot_parameters['j6_limit_max']}" effort="0" velocity="1.0"/>
+      <limit
+        lower="${robot_parameters['j6_limit_min']}"
+        upper="${robot_parameters['j6_limit_max']}"
+        effort="-1"
+        velocity="1.0472"
+      />
     </joint>
 
     <!-- center of the end effector mounting surface on link_6 -->

--- a/ar_gazebo/package.xml
+++ b/ar_gazebo/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ar_gazebo</name>
-  <version>0.1.0</version>
+  <version>2.0.0</version>
   <description>Gazebo simulation the AR4 robot</description>
   <author>Yifei Cheng</author>
   <maintainer email="ycheng517@gmail.com">Yifei Cheng</maintainer>

--- a/ar_hardware_interface/config/controllers.yaml
+++ b/ar_hardware_interface/config/controllers.yaml
@@ -22,8 +22,13 @@ joint_trajectory_controller:
       - joint_6
     command_interfaces:
       - position
+      - velocity
     state_interfaces:
       - position
+      - velocity
+    
+    action_monitor_rate: 20.0
+
     allow_partial_joints_goal: false
     constraints:
       stopped_velocity_tolerance: 0.02
@@ -34,6 +39,24 @@ joint_trajectory_controller:
       joint_4: { trajectory: 0.2, goal: 0.02 }
       joint_5: { trajectory: 0.2, goal: 0.02 }
       joint_6: { trajectory: 0.2, goal: 0.02 }
+
+    gains: # Required because we're controlling a velocity interface
+      joint_1: {p: 10.0,  d: 1.0, i: 1.0, i_clamp: 1.0}  # Smaller 'p' term, since ff term does most of the work
+      joint_2: {p: 10.0,  d: 1.0, i: 1.0, i_clamp: 1.0}
+      joint_3: {p: 10.0,  d: 1.0, i: 1.0, i_clamp: 1.0}
+      joint_4: {p: 10.0,  d: 1.0, i: 1.0, i_clamp: 1.0}
+      joint_5: {p: 10.0,  d: 1.0, i: 1.0, i_clamp: 1.0}
+      joint_6: {p: 10.0,  d: 1.0, i: 1.0, i_clamp: 1.0}
+
+    velocity_ff:
+      joint_1: 1.0
+      joint_2: 1.0
+      joint_3: 1.0
+      joint_4: 1.0
+      joint_5: 1.0
+      joint_6: 1.0
+
+    state_interfaces: ["position", "velocity"]
 
 gripper_controller:
   ros__parameters:

--- a/ar_hardware_interface/config/driver.yaml
+++ b/ar_hardware_interface/config/driver.yaml
@@ -1,1 +1,1 @@
-velocity_control_enabled: false
+velocity_control_enabled: true

--- a/ar_hardware_interface/config/driver.yaml
+++ b/ar_hardware_interface/config/driver.yaml
@@ -1,0 +1,1 @@
+velocity_control_enabled: false

--- a/ar_hardware_interface/include/ar_hardware_interface/ar_hardware_interface.hpp
+++ b/ar_hardware_interface/include/ar_hardware_interface/ar_hardware_interface.hpp
@@ -36,8 +36,10 @@ class ARHardwareInterface : public hardware_interface::SystemInterface {
 
   // Motor driver
   TeensyDriver driver_;
-  std::vector<double> actuator_commands_;
+  std::vector<double> actuator_pos_commands_;
+  std::vector<double> actuator_vel_commands_;
   std::vector<double> actuator_positions_;
+  std::vector<double> actuator_velocities_;
 
   // Shared memory
   std::vector<double> joint_offsets_;

--- a/ar_hardware_interface/include/ar_hardware_interface/teensy_driver.hpp
+++ b/ar_hardware_interface/include/ar_hardware_interface/teensy_driver.hpp
@@ -15,12 +15,13 @@ namespace ar_hardware_interface {
 class TeensyDriver {
  public:
   bool init(std::string ar_model, std::string port, int baudrate,
-            int num_joints);
-  void setStepperSpeed(std::vector<double>& max_speed,
-                       std::vector<double>& max_accel);
+            int num_joints, bool velocity_control_enabled);
   void update(std::vector<double>& pos_commands,
-              std::vector<double>& joint_states);
+              std::vector<double>& vel_commands,
+              std::vector<double>& joint_states,
+              std::vector<double>& joint_velocities);
   void getJointPositions(std::vector<double>& joint_positions);
+  void getJointVelocities(std::vector<double>& joint_velocities);
   bool calibrateJoints();
   bool resetEStop();
   bool isEStopped();
@@ -35,8 +36,11 @@ class TeensyDriver {
   boost::asio::serial_port serial_port_;
   int num_joints_;
   std::vector<double> joint_positions_deg_;
+  std::vector<double> joint_velocities_deg_;
   std::vector<int> enc_calibrations_;
+  bool velocity_control_enabled_ = true;
   bool is_estopped_;
+
   rclcpp::Logger logger_ = rclcpp::get_logger("teensy_driver");
   rclcpp::Clock clock_ = rclcpp::Clock(RCL_ROS_TIME);
 
@@ -47,10 +51,13 @@ class TeensyDriver {
   bool sendCommand(std::string outMsg);  // send arbitrary commands
 
   void checkInit(std::string msg);
+
+  template <typename T>
+  void parseValuesToVector(const std::string msg, std::vector<T>& values);
   void updateEncoderCalibrations(std::string msg);
   void updateJointPositions(std::string msg);
+  void updateJointVelocities(std::string msg);
   void updateEStopStatus(std::string msg);
-  bool succeeded(std::string msg);
 };
 
 }  // namespace ar_hardware_interface

--- a/ar_hardware_interface/package.xml
+++ b/ar_hardware_interface/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ar_hardware_interface</name>
-  <version>0.1.0</version>
+  <version>2.0.0</version>
   <description>
     The ar_hardware_interface package provides the hardware interface for
     running an AR4 robot using the ros2_control software framework.
@@ -29,10 +29,8 @@
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>ros2_aruco</exec_depend>
   <exec_depend>ros2controlcli</exec_depend>
   <exec_depend>ros2launch</exec_depend>
-  <exec_depend>rviz2</exec_depend>
   <exec_depend>urdf</exec_depend>
   <exec_depend>xacro</exec_depend>
 

--- a/ar_hardware_interface/src/ar_hardware_interface.cpp
+++ b/ar_hardware_interface/src/ar_hardware_interface.cpp
@@ -74,15 +74,15 @@ hardware_interface::CallbackReturn ARHardwareInterface::on_activate(
     calibrated_ = true;
   }
 
-  // init position commands at current positions
-  driver_.getJointPositions(actuator_positions_);
-  for (size_t i = 0; i < info_.joints.size(); ++i) {
-    // apply offsets, convert from deg to rad for moveit
-    joint_positions_[i] = degToRad(actuator_positions_[i] + joint_offsets_[i]);
-    joint_velocities_[i] = degToRad(actuator_velocities_[i]);
-    joint_position_commands_[i] = joint_positions_[i];
-    joint_velocity_commands_[i] = joint_velocities_[i];
-  }
+  // // init position commands at current positions
+  // driver_.getJointPositions(actuator_positions_);
+  // for (size_t i = 0; i < info_.joints.size(); ++i) {
+  //   // apply offsets, convert from deg to rad for moveit
+  //   joint_positions_[i] = degToRad(actuator_positions_[i] +
+  //   joint_offsets_[i]); joint_velocities_[i] =
+  //   degToRad(actuator_velocities_[i]); joint_position_commands_[i] =
+  //   joint_positions_[i]; joint_velocity_commands_[i] = joint_velocities_[i];
+  // }
 
   return hardware_interface::CallbackReturn::SUCCESS;
 }
@@ -146,6 +146,7 @@ hardware_interface::return_type ARHardwareInterface::write(
         "reactivate the hardware component using 'ros2 "
         "run ar_hardware_interface reset_estop.sh'.";
     RCLCPP_WARN(logger_, logWarn.c_str());
+
     return hardware_interface::return_type::ERROR;
   }
   return hardware_interface::return_type::OK;

--- a/ar_hardware_interface/src/ar_hardware_interface.cpp
+++ b/ar_hardware_interface/src/ar_hardware_interface.cpp
@@ -74,16 +74,6 @@ hardware_interface::CallbackReturn ARHardwareInterface::on_activate(
     calibrated_ = true;
   }
 
-  // // init position commands at current positions
-  // driver_.getJointPositions(actuator_positions_);
-  // for (size_t i = 0; i < info_.joints.size(); ++i) {
-  //   // apply offsets, convert from deg to rad for moveit
-  //   joint_positions_[i] = degToRad(actuator_positions_[i] +
-  //   joint_offsets_[i]); joint_velocities_[i] =
-  //   degToRad(actuator_velocities_[i]); joint_position_commands_[i] =
-  //   joint_positions_[i]; joint_velocity_commands_[i] = joint_velocities_[i];
-  // }
-
   return hardware_interface::CallbackReturn::SUCCESS;
 }
 

--- a/ar_hardware_interface/src/arduino_nano_driver.cpp
+++ b/ar_hardware_interface/src/arduino_nano_driver.cpp
@@ -61,7 +61,7 @@ bool ArduinoNanoDriver::transmit(std::string msg, std::string& err) {
   if (!ec) {
     return true;
   } else {
-    err = "Error in transmit";
+    err = ec.message();
     return false;
   }
 }

--- a/ar_hardware_interface/src/teensy_driver.cpp
+++ b/ar_hardware_interface/src/teensy_driver.cpp
@@ -135,6 +135,7 @@ void TeensyDriver::getJointPositions(std::vector<double>& joint_positions) {
 
 bool TeensyDriver::resetEStop() {
   std::string msg = "RE\n";
+  exchange(msg);
   return !is_estopped_;
 }
 
@@ -142,6 +143,7 @@ bool TeensyDriver::isEStopped() { return is_estopped_; }
 
 void TeensyDriver::getJointVelocities(std::vector<double>& joint_velocities) {
   // get current joint velocities
+  std::string msg = "JV\n";
   exchange(msg);
   joint_velocities = joint_velocities_deg_;
 }

--- a/ar_hardware_interface/src/teensy_driver.cpp
+++ b/ar_hardware_interface/src/teensy_driver.cpp
@@ -4,7 +4,7 @@
 #include <stdexcept>
 #include <thread>
 
-#define FW_VERSION "0.2.0"
+#define FW_VERSION "2.0.0"
 
 namespace ar_hardware_interface {
 

--- a/ar_hardware_interface/urdf/ar.urdf.xacro
+++ b/ar_hardware_interface/urdf/ar.urdf.xacro
@@ -22,6 +22,7 @@
     calibrate="$(arg calibrate)"
     robot_parameters_file="$(find ar_description)/config/$(arg ar_model).yaml"
     joint_offset_parameters_file="$(find ar_hardware_interface)/config/joint_offsets/$(arg ar_model).yaml"
+    driver_parameters_file="$(find ar_hardware_interface)/config/driver.yaml"
   />
 
   <xacro:if value="$(arg include_gripper)">

--- a/ar_microcontrollers/AR4_teensy/AR4_teensy.ino
+++ b/ar_microcontrollers/AR4_teensy/AR4_teensy.ino
@@ -7,7 +7,7 @@
 #include <map>
 
 // Firmware version
-const char* VERSION = "0.2.0";
+const char* VERSION = "2.0.0";
 
 // Model of the AR4, i.e. mk1, mk2, mk3
 String MODEL = "";

--- a/ar_moveit_config/config/joint_limits.yaml
+++ b/ar_moveit_config/config/joint_limits.yaml
@@ -1,5 +1,7 @@
 # These limits are used by MoveIt and augment/override the definitions in
 # ur_description.
+# You can confirm parameters are loaded despite warning, by:
+# ros2 param get /move_group robot_description_planning.joint_limits.joint_1.max_deceleration
 joint_limits:
   joint_1:
     has_acceleration_limits: true
@@ -36,3 +38,9 @@ joint_limits:
     max_acceleration: 0.01 # m/s^2
     has_velocity_limits: true
     max_velocity: 0.02 # m/s
+
+cartesian_limits:
+  max_trans_vel: 0.05 # m/s
+  max_trans_acc: 0.01 # m/s^2
+  max_trans_dec: -0.01 # m/s^2
+  max_rot_vel: 0.08727 # 5 deg/s

--- a/ar_moveit_config/config/joint_limits.yaml
+++ b/ar_moveit_config/config/joint_limits.yaml
@@ -5,39 +5,53 @@
 joint_limits:
   joint_1:
     has_acceleration_limits: true
-    max_acceleration: 0.08727 # 5 deg/s^2
+    max_acceleration: 0.5236 # 30 deg/s^2
+    has_deceleration_limits: true
+    max_deceleration: 0.5236 # 30 deg/s^2
     has_velocity_limits: true
-    max_velocity: 0.2618 # 15 deg/s
+    max_velocity: 1.0472 # 60 deg/s
   joint_2:
     has_acceleration_limits: true
-    max_acceleration: 0.08727 # 5 deg/s^2
+    max_acceleration: 0.5236 # 30 deg/s^2
+    has_deceleration_limits: true
+    max_deceleration: 0.5236 # 30 deg/s^2
     has_velocity_limits: true
-    max_velocity: 0.2618 # 15 deg/s
+    max_velocity: 1.0472 # 60 deg/s
   joint_3:
     has_acceleration_limits: true
-    max_acceleration: 0.08727 # 5 deg/s^2
+    max_acceleration: 0.5236 # 30 deg/s^2
+    has_deceleration_limits: true
+    max_deceleration: 0.5236 # 30 deg/s^2
     has_velocity_limits: true
-    max_velocity: 0.2618 # 15 deg/s
+    max_velocity: 1.0472 # 60 deg/s
   joint_4:
     has_acceleration_limits: true
-    max_acceleration: 0.08727 # 5 deg/s^2
+    max_acceleration: 0.5236 # 30 deg/s^2
+    has_deceleration_limits: true
+    max_deceleration: 0.5236 # 30 deg/s^2
     has_velocity_limits: true
-    max_velocity: 0.2618 # 15 deg/s
+    max_velocity: 1.0472 # 60 deg/s
   joint_5:
     has_acceleration_limits: true
-    max_acceleration: 0.174533 # 10 deg/s^2
+    max_acceleration: 0.5236 # 30 deg/s^2
+    has_deceleration_limits: true
+    max_deceleration: 0.5236 # 30 deg/s^2
     has_velocity_limits: true
-    max_velocity: 0.261799 # 30 deg/s
+    max_velocity: 1.0472 # 60 deg/s
   joint_6:
     has_acceleration_limits: true
-    max_acceleration: 0.174533 # 10 deg/s^2
+    max_acceleration: 0.5236 # 30 deg/s^2
+    has_deceleration_limits: true
+    max_deceleration: 0.5236 # 30 deg/s^2
     has_velocity_limits: true
-    max_velocity: 0.261799 # 30 deg/s
+    max_velocity: 1.0472 # 60 deg/s
   gripper_jaw1_joint:
     has_acceleration_limits: true
-    max_acceleration: 0.01 # m/s^2
+    max_acceleration: 0.1 # m/s^2
+    has_deceleration_limits: true
+    max_deceleration: 0.1 # m/s^2
     has_velocity_limits: true
-    max_velocity: 0.02 # m/s
+    max_velocity: 0.05 # m/s
 
 cartesian_limits:
   max_trans_vel: 0.05 # m/s

--- a/ar_moveit_config/config/ompl_planning.yaml
+++ b/ar_moveit_config/config/ompl_planning.yaml
@@ -1,5 +1,4 @@
-planning_plugins:
-  - ompl_interface/OMPLPlanner
+planning_plugin: ompl_interface/OMPLPlanner
 request_adapters: >-
   default_planner_request_adapters/AddTimeOptimalParameterization
   default_planner_request_adapters/ResolveConstraintFrames
@@ -62,6 +61,7 @@ planner_configs:
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 ar_manipulator:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault
@@ -78,6 +78,7 @@ ar_manipulator:
   #projection_evaluator: joints(shoulder_pan_joint,shoulder_lift_joint)
   longest_valid_segment_fraction: 0.01
 ar_gripper:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault
@@ -90,3 +91,5 @@ ar_gripper:
     - TRRTkConfigDefault
     - PRMkConfigDefault
     - PRMstarkConfigDefault
+
+start_state_max_bounds_error: 0.1

--- a/ar_moveit_config/config/pilz_planning.yaml
+++ b/ar_moveit_config/config/pilz_planning.yaml
@@ -1,0 +1,14 @@
+planning_plugin: pilz_industrial_motion_planner/CommandPlanner
+request_adapters: >-
+  default_planner_request_adapters/FixWorkspaceBounds
+  default_planner_request_adapters/FixStartStateBounds
+  default_planner_request_adapters/FixStartStateCollision
+  default_planner_request_adapters/FixStartStatePathConstraints
+capabilities: >-
+  pilz_industrial_motion_planner/MoveGroupSequenceAction
+  pilz_industrial_motion_planner/MoveGroupSequenceService
+
+ar_manipulator:
+  default_planner_config: PTP
+
+start_state_max_bounds_error: 0.1

--- a/ar_moveit_config/launch/ar_moveit.launch.py
+++ b/ar_moveit_config/launch/ar_moveit.launch.py
@@ -134,17 +134,16 @@ def generate_launch_description():
     }
 
     # Planning Configuration
-    ompl_planning_pipeline_config = {
-        "default_planning_pipeline": "ompl",
-        "planning_pipelines": ["ompl"],
-        "ompl": {
-            "planning_plugin": "ompl_interface/OMPLPlanner",
-            "start_state_max_bounds_error": 0.1,
-        }
-    }
     ompl_planning_yaml = load_yaml("ar_moveit_config",
                                    "config/ompl_planning.yaml")
-    ompl_planning_pipeline_config["ompl"].update(ompl_planning_yaml)
+    pilz_planning_yaml = load_yaml("ar_moveit_config",
+                                   "config/pilz_planning.yaml")
+    planning_pipeline_config = {
+        "default_planning_pipeline": "ompl",
+        "planning_pipelines": ["ompl", "pilz"],
+        "ompl": ompl_planning_yaml,
+        "pilz": pilz_planning_yaml,
+    }
 
     # Trajectory Execution Configuration
     controllers_yaml = load_yaml("ar_moveit_config", "config/controllers.yaml")
@@ -173,6 +172,11 @@ def generate_launch_description():
         # Two above added due to https://github.com/moveit/moveit2_tutorials/issues/528
     }
 
+    # Starts Pilz Industrial Motion Planner MoveGroupSequenceAction and MoveGroupSequenceService servers
+    move_group_capabilities = {
+        "capabilities": "pilz_industrial_motion_planner/MoveGroupSequenceAction pilz_industrial_motion_planner/MoveGroupSequenceService"
+    }
+
     # Start the actual move_group node/action server
     move_group_node = Node(
         package="moveit_ros_move_group",
@@ -183,10 +187,11 @@ def generate_launch_description():
             robot_description_semantic,
             robot_description_kinematics,
             robot_description_planning,
-            ompl_planning_pipeline_config,
+            planning_pipeline_config,
             trajectory_execution,
             moveit_controllers,
             planning_scene_monitor_parameters,
+            move_group_capabilities,
             {
                 "use_sim_time": use_sim_time
             },
@@ -205,7 +210,7 @@ def generate_launch_description():
         parameters=[
             robot_description,
             robot_description_semantic,
-            ompl_planning_pipeline_config,
+            planning_pipeline_config,
             robot_description_kinematics,
             robot_description_planning,
         ],

--- a/ar_moveit_config/launch/ar_moveit.launch.py
+++ b/ar_moveit_config/launch/ar_moveit.launch.py
@@ -168,7 +168,7 @@ def generate_launch_description():
         "publish_state_updates": True,
         "publish_transforms_updates": True,
         "publish_robot_description": True,
-        "publish_robot_description_semantic": True
+        "publish_robot_description_semantic": True,
         # Two above added due to https://github.com/moveit/moveit2_tutorials/issues/528
     }
 
@@ -213,6 +213,7 @@ def generate_launch_description():
             planning_pipeline_config,
             robot_description_kinematics,
             robot_description_planning,
+            {"use_sim_time": use_sim_time},
         ],
     )
 

--- a/ar_moveit_config/launch/demo.launch.py
+++ b/ar_moveit_config/launch/demo.launch.py
@@ -78,19 +78,16 @@ def generate_launch_description():
     }
 
     # Planning Configuration
-    ompl_planning_pipeline_config = {
-        "default_planning_pipeline": "ompl",
-        "planning_pipelines": ["ompl"],
-        "ompl": {
-            "planning_plugin": "ompl_interface/OMPLPlanner",
-            "request_adapters":
-            """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""",
-            "start_state_max_bounds_error": 0.1,
-        }
-    }
     ompl_planning_yaml = load_yaml("ar_moveit_config",
                                    "config/ompl_planning.yaml")
-    ompl_planning_pipeline_config["ompl"].update(ompl_planning_yaml)
+    pilz_planning_yaml = load_yaml("ar_moveit_config",
+                                   "config/pilz_planning.yaml")
+    planning_pipeline_config = {
+        "default_planning_pipeline": "ompl",
+        "planning_pipelines": ["ompl", "pilz"],
+        "ompl": ompl_planning_yaml,
+        "pilz": pilz_planning_yaml,
+    }
 
     # Trajectory Execution Configuration
     controllers_yaml = load_yaml("ar_moveit_config", "config/controllers.yaml")
@@ -116,6 +113,11 @@ def generate_launch_description():
         "publish_transforms_updates": True,
     }
 
+    # Starts Pilz Industrial Motion Planner MoveGroupSequenceAction and MoveGroupSequenceService servers
+    move_group_capabilities = {
+        "capabilities": "pilz_industrial_motion_planner/MoveGroupSequenceAction pilz_industrial_motion_planner/MoveGroupSequenceService"
+    }
+
     # Start the actual move_group node/action server
     run_move_group_node = Node(
         package="moveit_ros_move_group",
@@ -126,10 +128,11 @@ def generate_launch_description():
             robot_description_semantic,
             robot_description_kinematics,
             robot_description_planning,
-            ompl_planning_pipeline_config,
+            planning_pipeline_config,
             trajectory_execution,
             moveit_controllers,
             planning_scene_monitor_parameters,
+            move_group_capabilities,
         ],
     )
 
@@ -149,7 +152,7 @@ def generate_launch_description():
             robot_description_semantic,
             robot_description_kinematics,
             robot_description_planning,
-            ompl_planning_pipeline_config,
+            planning_pipeline_config,
             trajectory_execution,
             moveit_controllers,
             planning_scene_monitor_parameters,

--- a/ar_moveit_config/package.xml
+++ b/ar_moveit_config/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
   <name>ar_moveit_config</name>
-  <version>0.1.0</version>
+  <version>2.0.0</version>
   <description>
     Configuration and launch files for using the AR4 robot with MoveIt 2
   </description>

--- a/ar_moveit_config/srdf/ar_macro.srdf.xacro
+++ b/ar_moveit_config/srdf/ar_macro.srdf.xacro
@@ -25,7 +25,7 @@
     <group_state name="upright" group="ar_manipulator">
       <joint name="joint_1" value="0" />
       <joint name="joint_2" value="-0.087" />
-      <joint name="joint_3" value="-1.34" />
+      <joint name="joint_3" value="-1.4" />
       <joint name="joint_4" value="0" />
       <joint name="joint_5" value="0" />
       <joint name="joint_6" value="0" />

--- a/ar_moveit_config/urdf/fake_ar.urdf.xacro
+++ b/ar_moveit_config/urdf/fake_ar.urdf.xacro
@@ -21,6 +21,7 @@
     calibrate="False"
     robot_parameters_file="$(find ar_description)/config/$(arg ar_model).yaml"
     joint_offset_parameters_file="$(find ar_hardware_interface)/config/joint_offsets/$(arg ar_model).yaml"
+    driver_parameters_file="$(find ar_hardware_interface)/config/driver.yaml"
   />
   <xacro:ar_gripper_ros2_control
     name="ARGripperFakeSystem"


### PR DESCRIPTION
Adopt some contributions by @navdotnetreqs

- Use velocity-based position control by default, which allows the arm to move much faster.
- Use Bounce2 to handle de-bouncing of switches
- Add PILZ motion planner 