### PR TITLE
Adding tf_prefix/prefix to .urdf, .srdf and launch files

### DIFF
--- a/ar_description/urdf/ar.ros2_control.xacro
+++ b/ar_description/urdf/ar.ros2_control.xacro
@@ -9,6 +9,7 @@
     robot_parameters_file
     joint_offset_parameters_file
     driver_parameters_file
+    tf_prefix
   ">
 
     <xacro:property name="robot_parameters"
@@ -28,9 +29,10 @@
         <param name="serial_port">${serial_port}</param>
         <param name="calibrate">${calibrate}</param>
         <param name="velocity_control_enabled">${driver_parameters['velocity_control_enabled']}</param>
+        <param name="tf_prefix">${tf_prefix}</param>
       </hardware>
 
-      <joint name="joint_1">
+      <joint name="${tf_prefix}joint_1">
         <command_interface name="position">
           <param name="min">${robot_parameters['j1_limit_min']}</param>
           <param name="max">${robot_parameters['j1_limit_max']}</param>
@@ -45,7 +47,7 @@
         <param name="position_offset">${joint_offset_parameters['joint_1']}</param>
       </joint>
 
-      <joint name="joint_2">
+      <joint name="${tf_prefix}joint_2">
         <command_interface name="position">
           <param name="min">${robot_parameters['j2_limit_min']}</param>
           <param name="max">${robot_parameters['j2_limit_max']}</param>
@@ -60,7 +62,7 @@
         <param name="position_offset">${joint_offset_parameters['joint_2']}</param>
       </joint>
 
-      <joint name="joint_3">
+      <joint name="${tf_prefix}joint_3">
         <command_interface name="position">
           <param name="min">${robot_parameters['j3_limit_min']}</param>
           <param name="max">${robot_parameters['j3_limit_max']}</param>
@@ -75,7 +77,7 @@
         <param name="position_offset">${joint_offset_parameters['joint_3']}</param>
       </joint>
 
-      <joint name="joint_4">
+      <joint name="${tf_prefix}joint_4">
         <command_interface name="position">
           <param name="min">${robot_parameters['j4_limit_min']}</param>
           <param name="max">${robot_parameters['j4_limit_max']}</param>
@@ -90,7 +92,7 @@
         <param name="position_offset">${joint_offset_parameters['joint_4']}</param>
       </joint>
 
-      <joint name="joint_5">
+      <joint name="${tf_prefix}joint_5">
         <command_interface name="position">
           <param name="min">${robot_parameters['j5_limit_min']}</param>
           <param name="max">${robot_parameters['j5_limit_max']}</param>
@@ -105,7 +107,7 @@
         <param name="position_offset">${joint_offset_parameters['joint_5']}</param>
       </joint>
 
-      <joint name="joint_6">
+      <joint name="${tf_prefix}joint_6">
         <command_interface name="position">
           <param name="min">${robot_parameters['j6_limit_min']}</param>
           <param name="max">${robot_parameters['j6_limit_max']}</param>

--- a/ar_description/urdf/ar.urdf.xacro
+++ b/ar_description/urdf/ar.urdf.xacro
@@ -1,11 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="$(arg ar_model)">
+  <xacro:arg name="tf_prefix" default="" />
   <xacro:arg name="include_gripper" default="true"/>
 
   <xacro:include filename="$(find ar_description)/urdf/ar_macro.xacro"/>
 
   <link name="world" />
   <xacro:ar_robot
+    tf_prefix="$(arg tf_prefix)"
     parent="world"
     robot_parameters_file="$(find ar_description)/config/$(arg ar_model).yaml"
   >
@@ -14,6 +16,6 @@
 
   <xacro:if value="$(arg include_gripper)">
     <xacro:include filename="$(find ar_description)/urdf/ar_gripper_macro.xacro"/>
-    <xacro:ar_gripper parent="ee_link" />
+    <xacro:ar_gripper parent="$(arg tf_prefix)ee_link" />
   </xacro:if>
 </robot>

--- a/ar_description/urdf/ar_gazebo.urdf.xacro
+++ b/ar_description/urdf/ar_gazebo.urdf.xacro
@@ -6,15 +6,17 @@
   <xacro:include filename="$(find ar_description)/urdf/ar_gripper.ros2_control.xacro" />
 
   <xacro:arg name="simulation_controllers" default="" />
+  <xacro:arg name="tf_prefix" default="" />
 
   <link name="world" />
-  <xacro:ar_robot 
+  <xacro:ar_robot
+    tf_prefix="$(arg tf_prefix)"
     parent="world"
     robot_parameters_file="$(find ar_description)/config/$(arg ar_model).yaml"
   >
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:ar_robot>
-  <xacro:ar_gripper parent="ee_link" />
+  <xacro:ar_gripper parent="$(arg tf_prefix)ee_link" />
 
   <xacro:ar_ros2_control
     ar_model="$(arg ar_model)"
@@ -24,6 +26,7 @@
     robot_parameters_file="$(find ar_description)/config/$(arg ar_model).yaml"
     joint_offset_parameters_file="$(find ar_hardware_interface)/config/joint_offsets/$(arg ar_model).yaml"
     driver_parameters_file="$(find ar_hardware_interface)/config/driver.yaml"
+    tf_prefix="$(arg tf_prefix)"
   />
 
   <xacro:ar_gripper_ros2_control

--- a/ar_description/urdf/ar_macro.xacro
+++ b/ar_description/urdf/ar_macro.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:macro name="ar_robot" params="
+    tf_prefix
     parent
     *origin
     robot_parameters_file
@@ -8,13 +9,13 @@
 
     <xacro:property name="robot_parameters" value="${xacro.load_yaml(robot_parameters_file)}"/>
 
-    <joint name="base_joint" type="fixed">
+    <joint name="${tf_prefix}base_joint" type="fixed">
       <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
-      <child link="base_link" />
+      <child link="${tf_prefix}base_link" />
     </joint>
 
-    <link name="base_link">
+    <link name="${tf_prefix}base_link">
       <inertial>
         <origin rpy="0 0 0" xyz="-4.6941E-06 0.054174 0.038824"/>
         <mass value="0.7102"/>
@@ -36,7 +37,7 @@
         </geometry>
       </collision>
     </link>
-    <link name="link_1">
+    <link name="${tf_prefix}link_1">
       <inertial>
         <origin rpy="0 0 0" xyz="-0.022706 0.04294 -0.12205"/>
         <mass value="0.88065"/>
@@ -58,10 +59,10 @@
         </geometry>
       </collision>
     </link>
-    <joint name="joint_1" type="revolute">
+    <joint name="${tf_prefix}joint_1" type="revolute">
       <origin rpy="${pi} 0 0" xyz="0 0 0"/>
-      <parent link="base_link"/>
-      <child link="link_1"/>
+      <parent link="${tf_prefix}base_link"/>
+      <child link="${tf_prefix}link_1"/>
       <axis xyz="0 0 1"/>
       <limit
         lower="${robot_parameters['j1_limit_min']}"
@@ -70,7 +71,7 @@
         velocity="1.0472"
       />
     </joint>
-    <link name="link_2">
+    <link name="${tf_prefix}link_2">
       <inertial>
         <origin rpy="0 0 0" xyz="0.064818 -0.11189 -0.038671"/>
         <mass value="0.57738"/>
@@ -92,10 +93,10 @@
         </geometry>
       </collision>
     </link>
-    <joint name="joint_2" type="revolute">
+    <joint name="${tf_prefix}joint_2" type="revolute">
       <origin rpy="1.5708 0 -1.5708" xyz="0 0.0642 -0.16977"/>
-      <parent link="link_1"/>
-      <child link="link_2"/>
+      <parent link="${tf_prefix}link_1"/>
+      <child link="${tf_prefix}link_2"/>
       <axis xyz="0 0 -1"/>
       <limit 
         lower="${robot_parameters['j2_limit_min']}"
@@ -104,7 +105,7 @@
         velocity="1.0472"
       />
     </joint>
-    <link name="link_3">
+    <link name="${tf_prefix}link_3">
       <inertial>
         <origin rpy="0 0 0" xyz="-0.00029765 -0.023661 -0.0019125"/>
         <mass value="0.1787"/>
@@ -126,10 +127,10 @@
         </geometry>
       </collision>
     </link>
-    <joint name="joint_3" type="revolute">
+    <joint name="${tf_prefix}joint_3" type="revolute">
       <origin rpy="0 0 3.1416" xyz="0 -0.305 0.007"/>
-      <parent link="link_2"/>
-      <child link="link_3"/>
+      <parent link="${tf_prefix}link_2"/>
+      <child link="${tf_prefix}link_3"/>
       <axis xyz="0 0 -1"/>
       <limit
         lower="${robot_parameters['j3_limit_min']}"
@@ -138,7 +139,7 @@
         velocity="1.0472"
       />
     </joint>
-    <link name="link_4">
+    <link name="${tf_prefix}link_4">
       <inertial>
         <origin rpy="0 0 0" xyz="-0.0016798 -0.00057319 -0.074404"/>
         <mass value="0.34936"/>
@@ -160,10 +161,10 @@
         </geometry>
       </collision>
     </link>
-    <joint name="joint_4" type="revolute">
+    <joint name="${tf_prefix}joint_4" type="revolute">
       <origin rpy="1.5708 0 -1.5708" xyz="0 0 0.0"/>
-      <parent link="link_3"/>
-      <child link="link_4"/>
+      <parent link="${tf_prefix}link_3"/>
+      <child link="${tf_prefix}link_4"/>
       <axis xyz="0 0 -1"/>
       <limit
         lower="${robot_parameters['j4_limit_min']}"
@@ -172,7 +173,7 @@
         velocity="1.0472"
       />
     </joint>
-    <link name="link_5">
+    <link name="${tf_prefix}link_5">
       <inertial>
         <origin rpy="0 0 0" xyz="0.0015066 -1.3102E-05 -0.012585"/>
         <mass value="0.11562"/>
@@ -194,10 +195,10 @@
         </geometry>
       </collision>
     </link>
-    <joint name="joint_5" type="revolute">
+    <joint name="${tf_prefix}joint_5" type="revolute">
       <origin rpy="${pi} 0 -1.5708" xyz="0 0 -0.22263"/>
-      <parent link="link_4"/>
-      <child link="link_5"/>
+      <parent link="${tf_prefix}link_4"/>
+      <child link="${tf_prefix}link_5"/>
       <axis xyz="1 0 0"/>
       <limit
         lower="${robot_parameters['j5_limit_min']}"
@@ -206,7 +207,7 @@
         velocity="1.0472"
       />
     </joint>
-    <link name="link_6">
+    <link name="${tf_prefix}link_6">
       <inertial>
         <origin rpy="0 0 0" xyz="2.9287E-10 -1.6472E-09 0.0091432"/>
         <mass value="0.013863"/>
@@ -228,10 +229,10 @@
         </geometry>
       </collision>
     </link>
-    <joint name="joint_6" type="revolute">
+    <joint name="${tf_prefix}joint_6" type="revolute">
       <origin rpy="0 0 3.1416" xyz="0.000 0 ${robot_parameters['l6_length']}"/>
-      <parent link="link_5"/>
-      <child link="link_6"/>
+      <parent link="${tf_prefix}link_5"/>
+      <child link="${tf_prefix}link_6"/>
       <axis xyz="0 0 1"/>
       <limit
         lower="${robot_parameters['j6_limit_min']}"
@@ -242,10 +243,10 @@
     </joint>
 
     <!-- center of the end effector mounting surface on link_6 -->
-    <link name="ee_link" />
-    <joint name="ee_joint" type="fixed">
-      <parent link="link_6" />
-      <child link="ee_link" />
+    <link name="${tf_prefix}ee_link" />
+    <joint name="${tf_prefix}ee_joint" type="fixed">
+      <parent link="${tf_prefix}link_6" />
+      <child link="${tf_prefix}ee_link" />
       <origin xyz="0 0 0.0" rpy="0 0 0" />
     </joint>
 

--- a/ar_gazebo/launch/ar_gazebo.launch.py
+++ b/ar_gazebo/launch/ar_gazebo.launch.py
@@ -38,11 +38,17 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
+    tf_prefix_value = ""
+
     ar_model_arg = DeclareLaunchArgument("ar_model",
                                          default_value="mk3",
                                          choices=["mk1", "mk2", "mk3"],
                                          description="Model of AR4")
     ar_model_config = LaunchConfiguration("ar_model")
+    tf_prefix_arg = DeclareLaunchArgument("tf_prefix",
+                                         default_value=tf_prefix_value,
+                                         description="Prefix for AR4 tf_tree")
+    tf_prefix = LaunchConfiguration("tf_prefix")
 
     initial_joint_controllers = PathJoinSubstitution([
         FindPackageShare("ar_hardware_interface"), "config", "controllers.yaml"
@@ -57,6 +63,9 @@ def generate_launch_description():
         " ",
         "ar_model:=",
         ar_model_config,
+        " ",
+        "tf_prefix:=",
+        tf_prefix,
         " ",
         "simulation_controllers:=",
         initial_joint_controllers,
@@ -119,6 +128,7 @@ def generate_launch_description():
 
     return LaunchDescription([
         ar_model_arg,
+        tf_prefix_arg,
         robot_state_publisher_node,
         joint_state_broadcaster_spawner,
         initial_joint_controller_spawner_started,

--- a/ar_hardware_interface/launch/ar_hardware.launch.py
+++ b/ar_hardware_interface/launch/ar_hardware.launch.py
@@ -15,6 +15,10 @@ def generate_launch_description():
     include_gripper = LaunchConfiguration("include_gripper")
     arduino_serial_port = LaunchConfiguration("arduino_serial_port")
     ar_model_config = LaunchConfiguration("ar_model")
+    # tf_prefix_arg = DeclareLaunchArgument("tf_prefix",
+    #                                      default_value=tf_prefix_value,
+    #                                      description="Prefix for AR4 tf_tree")
+    tf_prefix = LaunchConfiguration("tf_prefix")
 
     robot_description_content = Command([
         PathJoinSubstitution([FindExecutable(name="xacro")]),
@@ -31,6 +35,9 @@ def generate_launch_description():
         " ",
         "calibrate:=",
         calibrate,
+        " ",
+        "tf_prefix:=",
+        tf_prefix,
         " ",
         "include_gripper:=",
         include_gripper,
@@ -118,6 +125,13 @@ def generate_launch_description():
             default_value="True",
             description="Calibrate the robot on startup",
             choices=["True", "False"],
+        ))
+    ld.add_action(
+        DeclareLaunchArgument(
+            "tf_prefix",
+            default_value="ar4_",
+            description="Prefix for AR4 tf_tree",
+            # choices=["True", "False"],
         ))
     ld.add_action(
         DeclareLaunchArgument(

--- a/ar_hardware_interface/urdf/ar.urdf.xacro
+++ b/ar_hardware_interface/urdf/ar.urdf.xacro
@@ -3,12 +3,14 @@
   <xacro:arg name="serial_port" default="/dev/ttyACM0"/>
   <xacro:arg name="arduino_serial_port" default="/dev/ttyUSB0"/>
   <xacro:arg name="calibrate" default="True"/>
+  <xacro:arg name="tf_prefix" default="" />
   <xacro:arg name="include_gripper" default="true"/>
   <xacro:include filename="$(find ar_description)/urdf/ar_macro.xacro"/>
   <xacro:include filename="$(find ar_description)/urdf/ar.ros2_control.xacro"/>
   
   <link name="world" />
   <xacro:ar_robot
+    tf_prefix="$(arg tf_prefix)"
     parent="world"
     robot_parameters_file="$(find ar_description)/config/$(arg ar_model).yaml"
   >
@@ -23,13 +25,14 @@
     robot_parameters_file="$(find ar_description)/config/$(arg ar_model).yaml"
     joint_offset_parameters_file="$(find ar_hardware_interface)/config/joint_offsets/$(arg ar_model).yaml"
     driver_parameters_file="$(find ar_hardware_interface)/config/driver.yaml"
+    tf_prefix="$(arg tf_prefix)"
   />
 
   <xacro:if value="$(arg include_gripper)">
     <xacro:include filename="$(find ar_description)/urdf/ar_gripper_macro.xacro"/>
     <xacro:include filename="$(find ar_description)/urdf/ar_gripper.ros2_control.xacro"/>
 
-    <xacro:ar_gripper parent="ee_link" />
+    <xacro:ar_gripper parent="$(arg tf_prefix)ee_link" />
 
     <xacro:ar_gripper_ros2_control
       name="ar_servo_gripper"

--- a/ar_moveit_config/launch/ar_moveit.launch.py
+++ b/ar_moveit_config/launch/ar_moveit.launch.py
@@ -71,7 +71,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "tf_prefix",
-            default_value="ar4_",
+            default_value="",
             description="Prefix for AR4 tf_tree",
             # choices=["True", "False"],
         ))

--- a/ar_moveit_config/launch/ar_moveit.launch.py
+++ b/ar_moveit_config/launch/ar_moveit.launch.py
@@ -58,6 +58,7 @@ def generate_launch_description():
     include_gripper = LaunchConfiguration("include_gripper")
     rviz_config_file = LaunchConfiguration("rviz_config_file")
     ar_model_config = LaunchConfiguration("ar_model")
+    tf_prefix = LaunchConfiguration("tf_prefix")
 
     declared_arguments = []
     declared_arguments.append(
@@ -66,6 +67,13 @@ def generate_launch_description():
             default_value="False",
             description="Make MoveIt use simulation time. This is needed "+\
                 "for trajectory planing in simulation.",
+        ))
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "tf_prefix",
+            default_value="ar4_",
+            description="Prefix for AR4 tf_tree",
+            # choices=["True", "False"],
         ))
     declared_arguments.append(
         DeclareLaunchArgument(
@@ -95,6 +103,9 @@ def generate_launch_description():
         "ar_model:=",
         ar_model_config,
         " ",
+        "tf_prefix:=",
+        tf_prefix,
+        " ",
         "include_gripper:=",
         include_gripper,
     ])
@@ -109,6 +120,9 @@ def generate_launch_description():
         " ",
         "name:=",
         ar_model_config,
+        " ",
+        "prefix:=",
+        tf_prefix,
         " ",
         "include_gripper:=",
         include_gripper,

--- a/ar_moveit_config/launch/demo.launch.py
+++ b/ar_moveit_config/launch/demo.launch.py
@@ -22,8 +22,9 @@ def load_yaml(package_name, file_name):
     with open(absolute_file_path, "r", encoding="utf-8") as file:
         return yaml.safe_load(file)
 
-
 def generate_launch_description():
+
+    tf_prefix_value = ""
 
     # Command-line arguments
     db_arg = DeclareLaunchArgument("db",
@@ -34,6 +35,10 @@ def generate_launch_description():
                                          choices=["mk1", "mk2", "mk3"],
                                          description="Model of AR4")
     ar_model_config = LaunchConfiguration("ar_model")
+    tf_prefix_arg = DeclareLaunchArgument("tf_prefix",
+                                         default_value=tf_prefix_value,
+                                         description="Prefix for AR4 tf_tree")
+    tf_prefix = LaunchConfiguration("tf_prefix")
 
     robot_description_content = Command([
         PathJoinSubstitution([FindExecutable(name="xacro")]),
@@ -44,6 +49,9 @@ def generate_launch_description():
         " ",
         "ar_model:=",
         ar_model_config,
+        " ",
+        "tf_prefix:=",
+        tf_prefix,
     ])
     robot_description = {"robot_description": robot_description_content}
 
@@ -56,6 +64,9 @@ def generate_launch_description():
         " ",
         "name:=",
         ar_model_config,
+        " ",
+        "prefix:=",
+        tf_prefix,
     ])
     robot_description_semantic = {
         "robot_description_semantic": robot_description_semantic_content
@@ -226,6 +237,7 @@ def generate_launch_description():
     return LaunchDescription([
         db_arg,
         ar_model_arg,
+        tf_prefix_arg,
         rviz_node,
         # static_tf,
         robot_state_publisher,

--- a/ar_moveit_config/srdf/ar.srdf.xacro
+++ b/ar_moveit_config/srdf/ar.srdf.xacro
@@ -2,12 +2,14 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="$(arg name)">
   <xacro:arg name="include_gripper" default="true"/>
 
+  <xacro:arg name="prefix" default="" />
+
   <xacro:include filename="$(find ar_moveit_config)/srdf/ar_macro.srdf.xacro"/>
-  <xacro:ar_srdf />
+  <xacro:ar_srdf prefix="$(arg prefix)"/>
 
   <xacro:if value="$(arg include_gripper)">
     <xacro:include filename="$(find ar_moveit_config)/srdf/ar_gripper_macro.srdf.xacro"/>
-    <xacro:ar_gripper_srdf />
+    <xacro:ar_gripper_srdf prefix="$(arg prefix)"/>
   </xacro:if>
 
 </robot>

--- a/ar_moveit_config/srdf/ar_gripper_macro.srdf.xacro
+++ b/ar_moveit_config/srdf/ar_gripper_macro.srdf.xacro
@@ -4,7 +4,7 @@
     A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
 -->
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-  <xacro:macro name="ar_gripper_srdf">
+  <xacro:macro name="ar_gripper_srdf" params="prefix">
     <group name="ar_gripper">
       <link name="gripper_base_link" />
       <link name="gripper_jaw1_link" />
@@ -21,7 +21,7 @@
     <disable_collisions link1="gripper_base_link" link2="gripper_jaw1_link" reason="Adjacent" />
     <disable_collisions link1="gripper_base_link" link2="gripper_jaw2_link" reason="Adjacent" />
     <disable_collisions link1="gripper_jaw1_link" link2="gripper_jaw2_link" reason="Default" />
-    <disable_collisions link1="link_6" link2="gripper_base_link" reason="Adjacent" />
-    <disable_collisions link1="link_5" link2="gripper_base_link" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_6" link2="gripper_base_link" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_5" link2="gripper_base_link" reason="Adjacent" />
   </xacro:macro>
 </robot>

--- a/ar_moveit_config/srdf/ar_macro.srdf.xacro
+++ b/ar_moveit_config/srdf/ar_macro.srdf.xacro
@@ -4,41 +4,41 @@
     A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
 -->
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-  <xacro:macro name="ar_srdf">
+  <xacro:macro name="ar_srdf" params="prefix">
     <group name="ar_manipulator">
-      <joint name="joint_1" />
-      <joint name="joint_2" />
-      <joint name="joint_3" />
-      <joint name="joint_4" />
-      <joint name="joint_5" />
-      <joint name="joint_6" />
-      <joint name="ee_joint"/>
+      <joint name="${prefix}joint_1" />
+      <joint name="${prefix}joint_2" />
+      <joint name="${prefix}joint_3" />
+      <joint name="${prefix}joint_4" />
+      <joint name="${prefix}joint_5" />
+      <joint name="${prefix}joint_6" />
+      <joint name="${prefix}ee_joint"/>
     </group>
     <group_state name="home" group="ar_manipulator">
-      <joint name="joint_1" value="0" />
-      <joint name="joint_2" value="0" />
-      <joint name="joint_3" value="0" />
-      <joint name="joint_4" value="0" />
-      <joint name="joint_5" value="0" />
-      <joint name="joint_6" value="0" />
+      <joint name="${prefix}joint_1" value="0" />
+      <joint name="${prefix}joint_2" value="0" />
+      <joint name="${prefix}joint_3" value="0" />
+      <joint name="${prefix}joint_4" value="0" />
+      <joint name="${prefix}joint_5" value="0" />
+      <joint name="${prefix}joint_6" value="0" />
     </group_state>
     <group_state name="upright" group="ar_manipulator">
-      <joint name="joint_1" value="0" />
-      <joint name="joint_2" value="-0.087" />
-      <joint name="joint_3" value="-1.4" />
-      <joint name="joint_4" value="0" />
-      <joint name="joint_5" value="0" />
-      <joint name="joint_6" value="0" />
+      <joint name="${prefix}joint_1" value="0" />
+      <joint name="${prefix}joint_2" value="-0.087" />
+      <joint name="${prefix}joint_3" value="-1.4" />
+      <joint name="${prefix}joint_4" value="0" />
+      <joint name="${prefix}joint_5" value="0" />
+      <joint name="${prefix}joint_6" value="0" />
     </group_state>
-    <disable_collisions link1="base_link" link2="link_1" reason="Adjacent" />
-    <disable_collisions link1="link_1" link2="link_2" reason="Adjacent" />
-    <disable_collisions link1="link_1" link2="link_3" reason="Never" />
-    <disable_collisions link1="link_2" link2="link_3" reason="Adjacent" />
-    <disable_collisions link1="link_3" link2="link_4" reason="Adjacent" />
-    <disable_collisions link1="link_3" link2="link_5" reason="Never" />
-    <disable_collisions link1="link_3" link2="link_6" reason="Never" />
-    <disable_collisions link1="link_4" link2="link_5" reason="Adjacent" />
-    <disable_collisions link1="link_5" link2="link_6" reason="Adjacent" />
+    <disable_collisions link1="${prefix}base_link" link2="${prefix}link_1" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_1" link2="${prefix}link_2" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_1" link2="${prefix}link_3" reason="Never" />
+    <disable_collisions link1="${prefix}link_2" link2="${prefix}link_3" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_3" link2="${prefix}link_4" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_3" link2="${prefix}link_5" reason="Never" />
+    <disable_collisions link1="${prefix}link_3" link2="${prefix}link_6" reason="Never" />
+    <disable_collisions link1="${prefix}link_4" link2="${prefix}link_5" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_5" link2="${prefix}link_6" reason="Adjacent" />
 
   </xacro:macro>
 </robot>

--- a/ar_moveit_config/urdf/fake_ar.urdf.xacro
+++ b/ar_moveit_config/urdf/fake_ar.urdf.xacro
@@ -5,14 +5,17 @@
   <xacro:include filename="$(find ar_description)/urdf/ar.ros2_control.xacro"/>
   <xacro:include filename="$(find ar_description)/urdf/ar_gripper.ros2_control.xacro"/>
 
+  <xacro:arg name="tf_prefix" default="" />
+
   <link name="world" />
   <xacro:ar_robot
+    tf_prefix="$(arg tf_prefix)"
     parent="world"
     robot_parameters_file="$(find ar_description)/config/$(arg ar_model).yaml"
   >
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:ar_robot>
-  <xacro:ar_gripper parent="ee_link" />
+  <xacro:ar_gripper parent="$(arg tf_prefix)ee_link" />
 
   <xacro:ar_ros2_control
     ar_model="$(arg ar_model)"
@@ -22,6 +25,7 @@
     robot_parameters_file="$(find ar_description)/config/$(arg ar_model).yaml"
     joint_offset_parameters_file="$(find ar_hardware_interface)/config/joint_offsets/$(arg ar_model).yaml"
     driver_parameters_file="$(find ar_hardware_interface)/config/driver.yaml"
+    tf_prefix="$(arg tf_prefix)"
   />
   <xacro:ar_gripper_ros2_control
     name="ARGripperFakeSystem"


### PR DESCRIPTION
> [**Note**] sorry, the previous pull request didn't have gazebo updated and I accidentally left a default value for the prefix in `ar_moveit.launch.py`

I've added the option of using a tf_prefix, when launching the robot. This allows giving all the links and joints a prefix at launch, so they don't have to be set individually (see [UR ROS2 Description](https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/blob/rolling/urdf/ur_macro.xacro) for reference). 

I left the gripper .urdf's alone, only adding the prefix variable to their parent and robot links in their .srdf's. 

The biggest issue, which I haven't figured out yet, is how to make the .yaml files use this prefix as well (`controllers.yaml`, `mk1.yaml` etc.) I was trying to edit them during launch, when they are loaded, but it wasn't fully functional (although I might have been looking at the wrong files). For now they need to be edited manually.

Let me know if this is any good, needs any changes etc. I did this in the iron branch as it's fully functional with humble, so should be easy to move there after. And the changes should be the same for further ROS versions as well. 