### PR TITLE
Adding tf_prefix to .urdf, .srdf and launch files to humble branch

### DIFF
--- a/annin_ar4_description/urdf/ar.ros2_control.xacro
+++ b/annin_ar4_description/urdf/ar.ros2_control.xacro
@@ -9,6 +9,7 @@
     robot_parameters_file
     joint_offset_parameters_file
     driver_parameters_file
+    tf_prefix
   ">
 
     <xacro:property name="robot_parameters"
@@ -28,9 +29,10 @@
         <param name="serial_port">${serial_port}</param>
         <param name="calibrate">${calibrate}</param>
         <param name="velocity_control_enabled">${driver_parameters['velocity_control_enabled']}</param>
+        <param name="tf_prefix">${tf_prefix}</param>
       </hardware>
 
-      <joint name="joint_1">
+      <joint name="${tf_prefix}joint_1">
         <command_interface name="position">
           <param name="min">${robot_parameters['j1_limit_min']}</param>
           <param name="max">${robot_parameters['j1_limit_max']}</param>
@@ -45,7 +47,7 @@
         <param name="position_offset">${joint_offset_parameters['joint_1']}</param>
       </joint>
 
-      <joint name="joint_2">
+      <joint name="${tf_prefix}joint_2">
         <command_interface name="position">
           <param name="min">${robot_parameters['j2_limit_min']}</param>
           <param name="max">${robot_parameters['j2_limit_max']}</param>
@@ -60,7 +62,7 @@
         <param name="position_offset">${joint_offset_parameters['joint_2']}</param>
       </joint>
 
-      <joint name="joint_3">
+      <joint name="${tf_prefix}joint_3">
         <command_interface name="position">
           <param name="min">${robot_parameters['j3_limit_min']}</param>
           <param name="max">${robot_parameters['j3_limit_max']}</param>
@@ -75,7 +77,7 @@
         <param name="position_offset">${joint_offset_parameters['joint_3']}</param>
       </joint>
 
-      <joint name="joint_4">
+      <joint name="${tf_prefix}joint_4">
         <command_interface name="position">
           <param name="min">${robot_parameters['j4_limit_min']}</param>
           <param name="max">${robot_parameters['j4_limit_max']}</param>
@@ -90,7 +92,7 @@
         <param name="position_offset">${joint_offset_parameters['joint_4']}</param>
       </joint>
 
-      <joint name="joint_5">
+      <joint name="${tf_prefix}joint_5">
         <command_interface name="position">
           <param name="min">${robot_parameters['j5_limit_min']}</param>
           <param name="max">${robot_parameters['j5_limit_max']}</param>
@@ -105,7 +107,7 @@
         <param name="position_offset">${joint_offset_parameters['joint_5']}</param>
       </joint>
 
-      <joint name="joint_6">
+      <joint name="${tf_prefix}joint_6">
         <command_interface name="position">
           <param name="min">${robot_parameters['j6_limit_min']}</param>
           <param name="max">${robot_parameters['j6_limit_max']}</param>

--- a/annin_ar4_description/urdf/ar.urdf.xacro
+++ b/annin_ar4_description/urdf/ar.urdf.xacro
@@ -1,11 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="$(arg ar_model)">
+  <xacro:arg name="tf_prefix" default="" />
   <xacro:arg name="include_gripper" default="true"/>
 
   <xacro:include filename="$(find annin_ar4_description)/urdf/ar_macro.xacro"/>
 
   <link name="world" />
   <xacro:ar_robot
+    tf_prefix="$(arg tf_prefix)"
     parent="world"
     robot_parameters_file="$(find annin_ar4_description)/config/$(arg ar_model).yaml"
   >
@@ -14,6 +16,6 @@
 
   <xacro:if value="$(arg include_gripper)">
     <xacro:include filename="$(find annin_ar4_description)/urdf/ar_gripper_macro.xacro"/>
-    <xacro:ar_gripper parent="ee_link" />
+    <xacro:ar_gripper parent="$(arg tf_prefix)ee_link" />
   </xacro:if>
 </robot>

--- a/annin_ar4_description/urdf/ar.urdf.xacro
+++ b/annin_ar4_description/urdf/ar.urdf.xacro
@@ -16,6 +16,9 @@
 
   <xacro:if value="$(arg include_gripper)">
     <xacro:include filename="$(find annin_ar4_description)/urdf/ar_gripper_macro.xacro"/>
-    <xacro:ar_gripper parent="$(arg tf_prefix)ee_link" />
+    <xacro:ar_gripper
+      tf_prefix="$(arg tf_prefix)"
+      parent="$(arg tf_prefix)ee_link"
+    />
   </xacro:if>
 </robot>

--- a/annin_ar4_description/urdf/ar_gazebo.urdf.xacro
+++ b/annin_ar4_description/urdf/ar_gazebo.urdf.xacro
@@ -16,7 +16,10 @@
   >
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:ar_robot>
-  <xacro:ar_gripper parent="$(arg tf_prefix)ee_link" />
+  <xacro:ar_gripper 
+    tf_prefix="$(arg tf_prefix)"
+    parent="$(arg tf_prefix)ee_link"
+  />
 
   <xacro:ar_ros2_control
     ar_model="$(arg ar_model)"
@@ -33,6 +36,7 @@
     name="ARGripperGazeboSystem"
     plugin_name="ign_ros2_control/IgnitionSystem"
     serial_port="None"
+    tf_prefix="$(arg tf_prefix)"
   />
 
   <gazebo reference="world" />

--- a/annin_ar4_description/urdf/ar_gazebo.urdf.xacro
+++ b/annin_ar4_description/urdf/ar_gazebo.urdf.xacro
@@ -6,15 +6,17 @@
   <xacro:include filename="$(find annin_ar4_description)/urdf/ar_gripper.ros2_control.xacro" />
 
   <xacro:arg name="simulation_controllers" default="" />
+  <xacro:arg name="tf_prefix" default="" />
 
   <link name="world" />
-  <xacro:ar_robot 
+  <xacro:ar_robot
+    tf_prefix="$(arg tf_prefix)"
     parent="world"
     robot_parameters_file="$(find annin_ar4_description)/config/$(arg ar_model).yaml"
   >
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:ar_robot>
-  <xacro:ar_gripper parent="ee_link" />
+  <xacro:ar_gripper parent="$(arg tf_prefix)ee_link" />
 
   <xacro:ar_ros2_control
     ar_model="$(arg ar_model)"
@@ -24,6 +26,7 @@
     robot_parameters_file="$(find annin_ar4_description)/config/$(arg ar_model).yaml"
     joint_offset_parameters_file="$(find annin_ar4_driver)/config/joint_offsets/$(arg ar_model).yaml"
     driver_parameters_file="$(find annin_ar4_driver)/config/driver.yaml"
+    tf_prefix="$(arg tf_prefix)"
   />
 
   <xacro:ar_gripper_ros2_control

--- a/annin_ar4_description/urdf/ar_gripper.ros2_control.xacro
+++ b/annin_ar4_description/urdf/ar_gripper.ros2_control.xacro
@@ -5,15 +5,17 @@
     name
     plugin_name
     serial_port
+    tf_prefix
   ">
     <ros2_control name="${name}" type="system">
 
       <hardware>
         <plugin>${plugin_name}</plugin>
         <param name="serial_port">${serial_port}</param>
+        <param name="tf_prefix">${tf_prefix}</param>
       </hardware>
 
-      <joint name="gripper_jaw1_joint">
+      <joint name="${tf_prefix}gripper_jaw1_joint">
         <command_interface name="position" />
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -22,8 +24,8 @@
           <param name="initial_value">0.0</param>
         </state_interface>
       </joint>
-      <joint name="gripper_jaw2_joint">
-        <param name="mimic">gripper_jaw1_joint</param>
+      <joint name="${tf_prefix}gripper_jaw2_joint">
+        <param name="mimic">${tf_prefix}gripper_jaw1_joint</param>
         <param name="multiplier">1</param>
         <state_interface name="position">
           <param name="initial_value">0.0</param>

--- a/annin_ar4_description/urdf/ar_gripper_macro.xacro
+++ b/annin_ar4_description/urdf/ar_gripper_macro.xacro
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-  <xacro:macro name="ar_gripper" params="parent">
+  <xacro:macro name="ar_gripper" params="
+    tf_prefix
+    parent
+  ">
 
-    <joint name="gripper_base_joint" type="fixed">
+    <joint name="${tf_prefix}gripper_base_joint" type="fixed">
       <origin xyz="0.0 0.0 0.0" rpy="-1.5708 0.0 0.0"/>
       <parent link="${parent}"/>
-      <child link="gripper_base_link"/>
+      <child link="${tf_prefix}gripper_base_link"/>
     </joint>
 
-    <link name="gripper_base_link">
+    <link name="${tf_prefix}gripper_base_link">
       <visual>
         <geometry>
           <mesh filename="file://$(find annin_ar4_description)/meshes/ar4_gripper/gripper_base_link.stl" />
@@ -28,7 +31,7 @@
         <inertia ixx="0.00002375" ixy="0.00000002" ixz="-0.00000017" iyy="0.00004082" iyz="-0.00000029" izz="0.00004254"/>
       </inertial>
     </link>
-    <link name="gripper_jaw1_link">
+    <link name="${tf_prefix}gripper_jaw1_link">
       <visual>
         <geometry>
           <mesh filename="file://$(find annin_ar4_description)/meshes/ar4_gripper/gripper_jaw1_link.stl" />
@@ -48,7 +51,7 @@
         <inertia ixx="0.00000123" ixy="-0.00000004" ixz="0.00000012" iyy="0.00000115" iyz="0.00000016" izz="0.00000102"/>
       </inertial>
     </link>
-    <link name="gripper_jaw2_link">
+    <link name="${tf_prefix}gripper_jaw2_link">
       <visual>
         <geometry>
           <mesh filename="file://$(find annin_ar4_description)/meshes/ar4_gripper/gripper_jaw2_link.stl" />
@@ -69,28 +72,28 @@
       </inertial>
     </link>
 
-    <joint name="gripper_jaw1_joint" type="prismatic">
+    <joint name="${tf_prefix}gripper_jaw1_joint" type="prismatic">
       <origin xyz="0.0 -0.036 0" rpy="0.0 0.0 0.0"/>
-      <parent link="gripper_base_link"/>
-      <child link="gripper_jaw1_link"/>
+      <parent link="${tf_prefix}gripper_base_link"/>
+      <child link="${tf_prefix}gripper_jaw1_link"/>
       <axis xyz="1 0 0"/>
       <limit lower="-0.014" upper="0" effort="1000" velocity="1.0"/>
     </joint>
 
-    <joint name="gripper_jaw2_joint" type="prismatic">
+    <joint name="${tf_prefix}gripper_jaw2_joint" type="prismatic">
       <origin xyz="0.0 -0.036 0" rpy="0.0 ${-pi} 0.0"/>
-      <parent link="gripper_base_link"/>
-      <child link="gripper_jaw2_link"/>
+      <parent link="${tf_prefix}gripper_base_link"/>
+      <child link="${tf_prefix}gripper_jaw2_link"/>
       <axis xyz="1 0 0"/>
       <limit lower="-0.014" upper="0" effort="1000" velocity="1.0"/>
-      <mimic joint="gripper_jaw1_joint" multiplier="1" offset="0"/>
+      <mimic joint="${tf_prefix}gripper_jaw1_joint" multiplier="1" offset="0"/>
     </joint>
 
     <!-- Fix for https://github.com/ros-controls/gz_ros2_control/issues/96 when running in sim -->
-    <link name="dummy_mimic_fix"/>
-    <joint name="gripper_jaw2_joint_mimic" type="fixed">
-      <parent link="gripper_base_link" />
-      <child link="dummy_mimic_fix" />
+    <link name="${tf_prefix}dummy_mimic_fix"/>
+    <joint name="${tf_prefix}gripper_jaw2_joint_mimic" type="fixed">
+      <parent link="${tf_prefix}gripper_base_link" />
+      <child link="${tf_prefix}dummy_mimic_fix" />
     </joint>
 
   </xacro:macro>

--- a/annin_ar4_description/urdf/ar_macro.xacro
+++ b/annin_ar4_description/urdf/ar_macro.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:macro name="ar_robot" params="
+    tf_prefix
     parent
     *origin
     robot_parameters_file
@@ -8,13 +9,13 @@
 
     <xacro:property name="robot_parameters" value="${xacro.load_yaml(robot_parameters_file)}"/>
 
-    <joint name="base_joint" type="fixed">
+    <joint name="${tf_prefix}base_joint" type="fixed">
       <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
-      <child link="base_link" />
+      <child link="${tf_prefix}base_link" />
     </joint>
 
-    <link name="base_link">
+    <link name="${tf_prefix}base_link">
       <inertial>
         <origin rpy="0 0 0" xyz="-4.6941E-06 0.054174 0.038824"/>
         <mass value="0.7102"/>
@@ -36,7 +37,7 @@
         </geometry>
       </collision>
     </link>
-    <link name="link_1">
+    <link name="${tf_prefix}link_1">
       <inertial>
         <origin rpy="0 0 0" xyz="-0.022706 0.04294 -0.12205"/>
         <mass value="0.88065"/>
@@ -58,10 +59,10 @@
         </geometry>
       </collision>
     </link>
-    <joint name="joint_1" type="revolute">
+    <joint name="${tf_prefix}joint_1" type="revolute">
       <origin rpy="${pi} 0 0" xyz="0 0 0"/>
-      <parent link="base_link"/>
-      <child link="link_1"/>
+      <parent link="${tf_prefix}base_link"/>
+      <child link="${tf_prefix}link_1"/>
       <axis xyz="0 0 1"/>
       <limit
         lower="${robot_parameters['j1_limit_min']}"
@@ -70,7 +71,7 @@
         velocity="1.0472"
       />
     </joint>
-    <link name="link_2">
+    <link name="${tf_prefix}link_2">
       <inertial>
         <origin rpy="0 0 0" xyz="0.064818 -0.11189 -0.038671"/>
         <mass value="0.57738"/>
@@ -92,10 +93,10 @@
         </geometry>
       </collision>
     </link>
-    <joint name="joint_2" type="revolute">
+    <joint name="${tf_prefix}joint_2" type="revolute">
       <origin rpy="1.5708 0 -1.5708" xyz="0 0.0642 -0.16977"/>
-      <parent link="link_1"/>
-      <child link="link_2"/>
+      <parent link="${tf_prefix}link_1"/>
+      <child link="${tf_prefix}link_2"/>
       <axis xyz="0 0 -1"/>
       <limit 
         lower="${robot_parameters['j2_limit_min']}"
@@ -104,7 +105,7 @@
         velocity="1.0472"
       />
     </joint>
-    <link name="link_3">
+    <link name="${tf_prefix}link_3">
       <inertial>
         <origin rpy="0 0 0" xyz="-0.00029765 -0.023661 -0.0019125"/>
         <mass value="0.1787"/>
@@ -126,10 +127,10 @@
         </geometry>
       </collision>
     </link>
-    <joint name="joint_3" type="revolute">
+    <joint name="${tf_prefix}joint_3" type="revolute">
       <origin rpy="0 0 3.1416" xyz="0 -0.305 0.007"/>
-      <parent link="link_2"/>
-      <child link="link_3"/>
+      <parent link="${tf_prefix}link_2"/>
+      <child link="${tf_prefix}link_3"/>
       <axis xyz="0 0 -1"/>
       <limit
         lower="${robot_parameters['j3_limit_min']}"
@@ -138,7 +139,7 @@
         velocity="1.0472"
       />
     </joint>
-    <link name="link_4">
+    <link name="${tf_prefix}link_4">
       <inertial>
         <origin rpy="0 0 0" xyz="-0.0016798 -0.00057319 -0.074404"/>
         <mass value="0.34936"/>
@@ -160,10 +161,10 @@
         </geometry>
       </collision>
     </link>
-    <joint name="joint_4" type="revolute">
+    <joint name="${tf_prefix}joint_4" type="revolute">
       <origin rpy="1.5708 0 -1.5708" xyz="0 0 0.0"/>
-      <parent link="link_3"/>
-      <child link="link_4"/>
+      <parent link="${tf_prefix}link_3"/>
+      <child link="${tf_prefix}link_4"/>
       <axis xyz="0 0 -1"/>
       <limit
         lower="${robot_parameters['j4_limit_min']}"
@@ -172,7 +173,7 @@
         velocity="1.0472"
       />
     </joint>
-    <link name="link_5">
+    <link name="${tf_prefix}link_5">
       <inertial>
         <origin rpy="0 0 0" xyz="0.0015066 -1.3102E-05 -0.012585"/>
         <mass value="0.11562"/>
@@ -194,10 +195,10 @@
         </geometry>
       </collision>
     </link>
-    <joint name="joint_5" type="revolute">
+    <joint name="${tf_prefix}joint_5" type="revolute">
       <origin rpy="${pi} 0 -1.5708" xyz="0 0 -0.22263"/>
-      <parent link="link_4"/>
-      <child link="link_5"/>
+      <parent link="${tf_prefix}link_4"/>
+      <child link="${tf_prefix}link_5"/>
       <axis xyz="1 0 0"/>
       <limit
         lower="${robot_parameters['j5_limit_min']}"
@@ -206,7 +207,7 @@
         velocity="1.0472"
       />
     </joint>
-    <link name="link_6">
+    <link name="${tf_prefix}link_6">
       <inertial>
         <origin rpy="0 0 0" xyz="2.9287E-10 -1.6472E-09 0.0091432"/>
         <mass value="0.013863"/>
@@ -228,10 +229,10 @@
         </geometry>
       </collision>
     </link>
-    <joint name="joint_6" type="revolute">
+    <joint name="${tf_prefix}joint_6" type="revolute">
       <origin rpy="0 0 3.1416" xyz="0.000 0 ${robot_parameters['l6_length']}"/>
-      <parent link="link_5"/>
-      <child link="link_6"/>
+      <parent link="${tf_prefix}link_5"/>
+      <child link="${tf_prefix}link_6"/>
       <axis xyz="0 0 1"/>
       <limit
         lower="${robot_parameters['j6_limit_min']}"
@@ -242,10 +243,10 @@
     </joint>
 
     <!-- center of the end effector mounting surface on link_6 -->
-    <link name="ee_link" />
-    <joint name="ee_joint" type="fixed">
-      <parent link="link_6" />
-      <child link="ee_link" />
+    <link name="${tf_prefix}ee_link" />
+    <joint name="${tf_prefix}ee_joint" type="fixed">
+      <parent link="${tf_prefix}link_6" />
+      <child link="${tf_prefix}ee_link" />
       <origin xyz="0 0 0.0" rpy="0 0 0" />
     </joint>
 

--- a/annin_ar4_driver/config/controllers.yaml
+++ b/annin_ar4_driver/config/controllers.yaml
@@ -14,12 +14,12 @@ controller_manager:
 joint_trajectory_controller:
   ros__parameters:
     joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
+      - $(var tf_prefix)joint_1
+      - $(var tf_prefix)joint_2
+      - $(var tf_prefix)joint_3
+      - $(var tf_prefix)joint_4
+      - $(var tf_prefix)joint_5
+      - $(var tf_prefix)joint_6
     command_interfaces:
       - position
       - velocity
@@ -33,29 +33,29 @@ joint_trajectory_controller:
     constraints:
       stopped_velocity_tolerance: 0.02
       goal_time: 0.0
-      joint_1: { trajectory: 0.2, goal: 0.02 }
-      joint_2: { trajectory: 0.2, goal: 0.02 }
-      joint_3: { trajectory: 0.2, goal: 0.02 }
-      joint_4: { trajectory: 0.2, goal: 0.02 }
-      joint_5: { trajectory: 0.2, goal: 0.02 }
-      joint_6: { trajectory: 0.2, goal: 0.02 }
+      $(var tf_prefix)joint_1: { trajectory: 0.2, goal: 0.02 }
+      $(var tf_prefix)joint_2: { trajectory: 0.2, goal: 0.02 }
+      $(var tf_prefix)joint_3: { trajectory: 0.2, goal: 0.02 }
+      $(var tf_prefix)joint_4: { trajectory: 0.2, goal: 0.02 }
+      $(var tf_prefix)joint_5: { trajectory: 0.2, goal: 0.02 }
+      $(var tf_prefix)joint_6: { trajectory: 0.2, goal: 0.02 }
 
     gains: # Required because we're controlling a velocity interface
-      joint_1: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 } # Smaller 'p' term, since ff term does most of the work
-      joint_2: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
-      joint_3: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
-      joint_4: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
-      joint_5: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
-      joint_6: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
+      $(var tf_prefix)joint_1: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 } # Smaller 'p' term, since ff term does most of the work
+      $(var tf_prefix)joint_2: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
+      $(var tf_prefix)joint_3: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
+      $(var tf_prefix)joint_4: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
+      $(var tf_prefix)joint_5: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
+      $(var tf_prefix)joint_6: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
 
     velocity_ff:
-      joint_1: 1.0
-      joint_2: 1.0
-      joint_3: 1.0
-      joint_4: 1.0
-      joint_5: 1.0
-      joint_6: 1.0
+      $(var tf_prefix)joint_1: 1.0
+      $(var tf_prefix)joint_2: 1.0
+      $(var tf_prefix)joint_3: 1.0
+      $(var tf_prefix)joint_4: 1.0
+      $(var tf_prefix)joint_5: 1.0
+      $(var tf_prefix)joint_6: 1.0
 
 gripper_controller:
   ros__parameters:
-    joint: gripper_jaw1_joint
+    joint: $(var tf_prefix)gripper_jaw1_joint

--- a/annin_ar4_driver/launch/driver.launch.py
+++ b/annin_ar4_driver/launch/driver.launch.py
@@ -63,6 +63,7 @@ def generate_launch_description():
         parameters=[
             update_rate_config_file,
             ParameterFile(joint_controllers_cfg, allow_substs=True),
+            {"tf_prefix": tf_prefix},
         ],
         remappings=[('~/robot_description', 'robot_description')],
         output="screen",

--- a/annin_ar4_driver/launch/driver.launch.py
+++ b/annin_ar4_driver/launch/driver.launch.py
@@ -15,9 +15,6 @@ def generate_launch_description():
     include_gripper = LaunchConfiguration("include_gripper")
     arduino_serial_port = LaunchConfiguration("arduino_serial_port")
     ar_model_config = LaunchConfiguration("ar_model")
-    # tf_prefix_arg = DeclareLaunchArgument("tf_prefix",
-    #                                      default_value=tf_prefix_value,
-    #                                      description="Prefix for AR4 tf_tree")
     tf_prefix = LaunchConfiguration("tf_prefix")
 
     robot_description_content = Command([
@@ -132,7 +129,6 @@ def generate_launch_description():
             "tf_prefix",
             default_value="ar4_",
             description="Prefix for AR4 tf_tree",
-            # choices=["True", "False"],
         ))
     ld.add_action(
         DeclareLaunchArgument(

--- a/annin_ar4_driver/launch/driver.launch.py
+++ b/annin_ar4_driver/launch/driver.launch.py
@@ -15,6 +15,10 @@ def generate_launch_description():
     include_gripper = LaunchConfiguration("include_gripper")
     arduino_serial_port = LaunchConfiguration("arduino_serial_port")
     ar_model_config = LaunchConfiguration("ar_model")
+    # tf_prefix_arg = DeclareLaunchArgument("tf_prefix",
+    #                                      default_value=tf_prefix_value,
+    #                                      description="Prefix for AR4 tf_tree")
+    tf_prefix = LaunchConfiguration("tf_prefix")
 
     robot_description_content = Command([
         PathJoinSubstitution([FindExecutable(name="xacro")]),
@@ -31,6 +35,9 @@ def generate_launch_description():
         " ",
         "calibrate:=",
         calibrate,
+        " ",
+        "tf_prefix:=",
+        tf_prefix,
         " ",
         "include_gripper:=",
         include_gripper,
@@ -118,6 +125,13 @@ def generate_launch_description():
             default_value="True",
             description="Calibrate the robot on startup",
             choices=["True", "False"],
+        ))
+    ld.add_action(
+        DeclareLaunchArgument(
+            "tf_prefix",
+            default_value="ar4_",
+            description="Prefix for AR4 tf_tree",
+            # choices=["True", "False"],
         ))
     ld.add_action(
         DeclareLaunchArgument(

--- a/annin_ar4_driver/urdf/ar.urdf.xacro
+++ b/annin_ar4_driver/urdf/ar.urdf.xacro
@@ -32,12 +32,16 @@
     <xacro:include filename="$(find annin_ar4_description)/urdf/ar_gripper_macro.xacro"/>
     <xacro:include filename="$(find annin_ar4_description)/urdf/ar_gripper.ros2_control.xacro"/>
 
-    <xacro:ar_gripper parent="$(arg tf_prefix)ee_link" />
+    <xacro:ar_gripper
+      tf_prefix="$(arg tf_prefix)"
+      parent="$(arg tf_prefix)ee_link"
+    />
 
     <xacro:ar_gripper_ros2_control
       name="ar_servo_gripper"
       plugin_name="annin_ar4_driver/ARServoGripperHWInterface"
       serial_port="$(arg arduino_serial_port)"
+      tf_prefix="$(arg tf_prefix)"
     />
   </xacro:if>
 

--- a/annin_ar4_driver/urdf/ar.urdf.xacro
+++ b/annin_ar4_driver/urdf/ar.urdf.xacro
@@ -3,12 +3,14 @@
   <xacro:arg name="serial_port" default="/dev/ttyACM0"/>
   <xacro:arg name="arduino_serial_port" default="/dev/ttyUSB0"/>
   <xacro:arg name="calibrate" default="True"/>
+  <xacro:arg name="tf_prefix" default="" />
   <xacro:arg name="include_gripper" default="true"/>
   <xacro:include filename="$(find annin_ar4_description)/urdf/ar_macro.xacro"/>
   <xacro:include filename="$(find annin_ar4_description)/urdf/ar.ros2_control.xacro"/>
   
   <link name="world" />
   <xacro:ar_robot
+    tf_prefix="$(arg tf_prefix)"
     parent="world"
     robot_parameters_file="$(find annin_ar4_description)/config/$(arg ar_model).yaml"
   >
@@ -23,13 +25,14 @@
     robot_parameters_file="$(find annin_ar4_description)/config/$(arg ar_model).yaml"
     joint_offset_parameters_file="$(find annin_ar4_driver)/config/joint_offsets/$(arg ar_model).yaml"
     driver_parameters_file="$(find annin_ar4_driver)/config/driver.yaml"
+    tf_prefix="$(arg tf_prefix)"
   />
 
   <xacro:if value="$(arg include_gripper)">
     <xacro:include filename="$(find annin_ar4_description)/urdf/ar_gripper_macro.xacro"/>
     <xacro:include filename="$(find annin_ar4_description)/urdf/ar_gripper.ros2_control.xacro"/>
 
-    <xacro:ar_gripper parent="ee_link" />
+    <xacro:ar_gripper parent="$(arg tf_prefix)ee_link" />
 
     <xacro:ar_gripper_ros2_control
       name="ar_servo_gripper"

--- a/annin_ar4_gazebo/CMakeLists.txt
+++ b/annin_ar4_gazebo/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(annin_ar4_gazebo)
 find_package(ament_cmake REQUIRED)
 
-install(DIRECTORY launch worlds
+install(DIRECTORY config launch worlds
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/annin_ar4_gazebo/config/controllers.yaml
+++ b/annin_ar4_gazebo/config/controllers.yaml
@@ -1,0 +1,61 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 100 # Hz
+
+    joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    gripper_controller:
+      type: position_controllers/GripperActionController
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+joint_trajectory_controller:
+  ros__parameters:
+    joints:
+      - joint_1
+      - joint_2
+      - joint_3
+      - joint_4
+      - joint_5
+      - joint_6
+    command_interfaces:
+      - position
+      - velocity
+    state_interfaces:
+      - position
+      - velocity
+
+    action_monitor_rate: 20.0
+    allow_partial_joints_goal: false
+    allow_nonzero_velocity_at_trajectory_end: true
+    constraints:
+      stopped_velocity_tolerance: 0.02
+      goal_time: 0.0
+      joint_1: { trajectory: 0.2, goal: 0.02 }
+      joint_2: { trajectory: 0.2, goal: 0.02 }
+      joint_3: { trajectory: 0.2, goal: 0.02 }
+      joint_4: { trajectory: 0.2, goal: 0.02 }
+      joint_5: { trajectory: 0.2, goal: 0.02 }
+      joint_6: { trajectory: 0.2, goal: 0.02 }
+
+    gains: # Required because we're controlling a velocity interface
+      joint_1: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 } # Smaller 'p' term, since ff term does most of the work
+      joint_2: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
+      joint_3: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
+      joint_4: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
+      joint_5: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
+      joint_6: { p: 10.0, d: 1.0, i: 1.0, i_clamp: 1.0 }
+
+    velocity_ff:
+      joint_1: 1.0
+      joint_2: 1.0
+      joint_3: 1.0
+      joint_4: 1.0
+      joint_5: 1.0
+      joint_6: 1.0
+
+gripper_controller:
+  ros__parameters:
+    joint: gripper_jaw1_joint

--- a/annin_ar4_gazebo/launch/gazebo.launch.py
+++ b/annin_ar4_gazebo/launch/gazebo.launch.py
@@ -45,6 +45,8 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
+    tf_prefix_value = ""
+
     ar_model_arg = DeclareLaunchArgument(
         "ar_model",
         default_value="mk3",
@@ -52,6 +54,10 @@ def generate_launch_description():
         description="Model of AR4",
     )
     ar_model_config = LaunchConfiguration("ar_model")
+    tf_prefix_arg = DeclareLaunchArgument("tf_prefix",
+                                         default_value=tf_prefix_value,
+                                         description="Prefix for AR4 tf_tree")
+    tf_prefix = LaunchConfiguration("tf_prefix")
 
     initial_joint_controllers = PathJoinSubstitution(
         [FindPackageShare("annin_ar4_driver"), "config", "controllers.yaml"]
@@ -71,6 +77,9 @@ def generate_launch_description():
             " ",
             "ar_model:=",
             ar_model_config,
+            " ",
+            "tf_prefix:=",
+            tf_prefix,
             " ",
             "simulation_controllers:=",
             initial_joint_controllers,
@@ -156,6 +165,7 @@ def generate_launch_description():
     return LaunchDescription(
         [
             ar_model_arg,
+            tf_prefix_arg,
             gazebo_bridge,
             gazebo,
             gazebo_spawn_robot,

--- a/annin_ar4_gazebo/launch/gazebo.launch.py
+++ b/annin_ar4_gazebo/launch/gazebo.launch.py
@@ -60,7 +60,7 @@ def generate_launch_description():
     tf_prefix = LaunchConfiguration("tf_prefix")
 
     initial_joint_controllers = PathJoinSubstitution(
-        [FindPackageShare("annin_ar4_driver"), "config", "controllers.yaml"]
+        [FindPackageShare("annin_ar4_gazebo"), "config", "controllers.yaml"]
     )
 
     robot_description_content = Command(

--- a/annin_ar4_gazebo/launch/gazebo.launch.py
+++ b/annin_ar4_gazebo/launch/gazebo.launch.py
@@ -45,8 +45,6 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    tf_prefix_value = ""
-
     ar_model_arg = DeclareLaunchArgument(
         "ar_model",
         default_value="mk3",
@@ -55,7 +53,7 @@ def generate_launch_description():
     )
     ar_model_config = LaunchConfiguration("ar_model")
     tf_prefix_arg = DeclareLaunchArgument("tf_prefix",
-                                         default_value=tf_prefix_value,
+                                         default_value="",
                                          description="Prefix for AR4 tf_tree")
     tf_prefix = LaunchConfiguration("tf_prefix")
 

--- a/annin_ar4_moveit_config/launch/demo.launch.py
+++ b/annin_ar4_moveit_config/launch/demo.launch.py
@@ -4,6 +4,7 @@ import yaml
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 from launch_ros.parameter_descriptions import ParameterFile
@@ -23,6 +24,9 @@ def load_yaml(package_name, file_name):
 
 
 def generate_launch_description():
+
+    tf_prefix_value = ""
+
     # Command-line arguments
     db_arg = DeclareLaunchArgument(
         "db", default_value="False", description="Database flag"
@@ -34,6 +38,12 @@ def generate_launch_description():
         description="Model of AR4",
     )
     ar_model_config = LaunchConfiguration("ar_model")
+    tf_prefix_arg = DeclareLaunchArgument(
+        "tf_prefix",
+        default_value=tf_prefix_value,
+        description="Prefix for AR4 tf_tree"
+    )
+    tf_prefix = LaunchConfiguration("tf_prefix")
 
     robot_description_content = Command(
         [
@@ -49,6 +59,9 @@ def generate_launch_description():
             " ",
             "ar_model:=",
             ar_model_config,
+            " ",
+            "tf_prefix:=",
+            tf_prefix,
         ]
     )
     robot_description = {"robot_description": robot_description_content}
@@ -64,6 +77,9 @@ def generate_launch_description():
             " ",
             "name:=",
             ar_model_config,
+            " ",
+            "prefix:=",
+            tf_prefix,
         ]
     )
     robot_description_semantic = {
@@ -225,6 +241,7 @@ def generate_launch_description():
         [
             db_arg,
             ar_model_arg,
+            tf_prefix_arg,
             rviz_node,
             # static_tf,
             robot_state_publisher,

--- a/annin_ar4_moveit_config/launch/demo.launch.py
+++ b/annin_ar4_moveit_config/launch/demo.launch.py
@@ -15,13 +15,11 @@ from launch.substitutions import (
     LaunchConfiguration,
 )
 
-
 def load_yaml(package_name, file_name):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_name)
     with open(absolute_file_path, "r", encoding="utf-8") as file:
         return yaml.safe_load(file)
-
 
 def generate_launch_description():
 
@@ -192,17 +190,17 @@ def generate_launch_description():
     )
 
     # ros2_control using FakeSystem as hardware
-    ros2_controllers_path = os.path.join(
-        get_package_share_directory("annin_ar4_driver"),
-        "config",
-        "controllers.yaml",
-    )
+    ros2_controllers = PathJoinSubstitution([
+        FindPackageShare("annin_ar4_driver"), "config", "controllers.yaml"
+    ])
+
     ros2_control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
         parameters=[
             robot_description,
-            ParameterFile(ros2_controllers_path, allow_substs=True),
+            ParameterFile(ros2_controllers, allow_substs=True),
+            {"tf_prefix": tf_prefix},
         ],
         output="both",
     )
@@ -242,10 +240,10 @@ def generate_launch_description():
             db_arg,
             ar_model_arg,
             tf_prefix_arg,
-            rviz_node,
             # static_tf,
-            robot_state_publisher,
             run_move_group_node,
+            rviz_node,
+            robot_state_publisher,
             ros2_control_node,
             joint_state_broadcaster_spawner,
             joint_controller_spawner,

--- a/annin_ar4_moveit_config/launch/demo.launch.py
+++ b/annin_ar4_moveit_config/launch/demo.launch.py
@@ -22,9 +22,6 @@ def load_yaml(package_name, file_name):
         return yaml.safe_load(file)
 
 def generate_launch_description():
-
-    tf_prefix_value = ""
-
     # Command-line arguments
     db_arg = DeclareLaunchArgument(
         "db", default_value="False", description="Database flag"
@@ -38,7 +35,7 @@ def generate_launch_description():
     ar_model_config = LaunchConfiguration("ar_model")
     tf_prefix_arg = DeclareLaunchArgument(
         "tf_prefix",
-        default_value=tf_prefix_value,
+        default_value="",
         description="Prefix for AR4 tf_tree"
     )
     tf_prefix = LaunchConfiguration("tf_prefix")

--- a/annin_ar4_moveit_config/launch/moveit.launch.py
+++ b/annin_ar4_moveit_config/launch/moveit.launch.py
@@ -74,7 +74,6 @@ def generate_launch_description():
             "tf_prefix",
             default_value="",
             description="Prefix for AR4 tf_tree",
-            # choices=["True", "False"],
         )
     )
     declared_arguments.append(

--- a/annin_ar4_moveit_config/launch/moveit.launch.py
+++ b/annin_ar4_moveit_config/launch/moveit.launch.py
@@ -58,6 +58,7 @@ def generate_launch_description():
     include_gripper = LaunchConfiguration("include_gripper")
     rviz_config_file = LaunchConfiguration("rviz_config_file")
     ar_model_config = LaunchConfiguration("ar_model")
+    tf_prefix = LaunchConfiguration("tf_prefix")
 
     declared_arguments = []
     declared_arguments.append(
@@ -66,6 +67,14 @@ def generate_launch_description():
             default_value="False",
             description="Make MoveIt use simulation time. This is needed "
             + "for trajectory planing in simulation.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "tf_prefix",
+            default_value="",
+            description="Prefix for AR4 tf_tree",
+            # choices=["True", "False"],
         )
     )
     declared_arguments.append(
@@ -106,6 +115,9 @@ def generate_launch_description():
             "ar_model:=",
             ar_model_config,
             " ",
+            "tf_prefix:=",
+            tf_prefix,
+            " ",
             "include_gripper:=",
             include_gripper,
         ]
@@ -123,6 +135,9 @@ def generate_launch_description():
             " ",
             "name:=",
             ar_model_config,
+            " ",
+            "prefix:=",
+            tf_prefix,
             " ",
             "include_gripper:=",
             include_gripper,

--- a/annin_ar4_moveit_config/srdf/ar.srdf.xacro
+++ b/annin_ar4_moveit_config/srdf/ar.srdf.xacro
@@ -2,12 +2,14 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="$(arg name)">
   <xacro:arg name="include_gripper" default="true"/>
 
+  <xacro:arg name="prefix" default="" />
+
   <xacro:include filename="$(find annin_ar4_moveit_config)/srdf/ar_macro.srdf.xacro"/>
-  <xacro:ar_srdf />
+  <xacro:ar_srdf prefix="$(arg prefix)"/>
 
   <xacro:if value="$(arg include_gripper)">
     <xacro:include filename="$(find annin_ar4_moveit_config)/srdf/ar_gripper_macro.srdf.xacro"/>
-    <xacro:ar_gripper_srdf />
+    <xacro:ar_gripper_srdf prefix="$(arg prefix)"/>
   </xacro:if>
 
 </robot>

--- a/annin_ar4_moveit_config/srdf/ar_gripper_macro.srdf.xacro
+++ b/annin_ar4_moveit_config/srdf/ar_gripper_macro.srdf.xacro
@@ -4,7 +4,7 @@
     A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
 -->
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-  <xacro:macro name="ar_gripper_srdf">
+  <xacro:macro name="ar_gripper_srdf" params="prefix">
     <group name="ar_gripper">
       <link name="gripper_base_link" />
       <link name="gripper_jaw1_link" />
@@ -21,7 +21,7 @@
     <disable_collisions link1="gripper_base_link" link2="gripper_jaw1_link" reason="Adjacent" />
     <disable_collisions link1="gripper_base_link" link2="gripper_jaw2_link" reason="Adjacent" />
     <disable_collisions link1="gripper_jaw1_link" link2="gripper_jaw2_link" reason="Default" />
-    <disable_collisions link1="link_6" link2="gripper_base_link" reason="Adjacent" />
-    <disable_collisions link1="link_5" link2="gripper_base_link" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_6" link2="gripper_base_link" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_5" link2="gripper_base_link" reason="Adjacent" />
   </xacro:macro>
 </robot>

--- a/annin_ar4_moveit_config/srdf/ar_gripper_macro.srdf.xacro
+++ b/annin_ar4_moveit_config/srdf/ar_gripper_macro.srdf.xacro
@@ -6,22 +6,22 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:macro name="ar_gripper_srdf" params="prefix">
     <group name="ar_gripper">
-      <link name="gripper_base_link" />
-      <link name="gripper_jaw1_link" />
-      <link name="gripper_jaw2_link" />
-      <joint name="gripper_jaw1_joint" />
-      <passive_joint name="gripper_jaw2_joint" />
+      <link name="${prefix}gripper_base_link" />
+      <link name="${prefix}gripper_jaw1_link" />
+      <link name="${prefix}gripper_jaw2_link" />
+      <joint name="${prefix}gripper_jaw1_joint" />
+      <passive_joint name="${prefix}gripper_jaw2_joint" />
     </group>
     <group_state name="open" group="ar_gripper">
-      <joint name="gripper_jaw1_joint" value="-0.012" />
+      <joint name="${prefix}gripper_jaw1_joint" value="-0.012" />
     </group_state>
     <group_state name="closed" group="ar_gripper">
-      <joint name="gripper_jaw1_joint" value="-0.001" />
+      <joint name="${prefix}gripper_jaw1_joint" value="-0.001" />
     </group_state>
-    <disable_collisions link1="gripper_base_link" link2="gripper_jaw1_link" reason="Adjacent" />
-    <disable_collisions link1="gripper_base_link" link2="gripper_jaw2_link" reason="Adjacent" />
-    <disable_collisions link1="gripper_jaw1_link" link2="gripper_jaw2_link" reason="Default" />
-    <disable_collisions link1="${prefix}link_6" link2="gripper_base_link" reason="Adjacent" />
-    <disable_collisions link1="${prefix}link_5" link2="gripper_base_link" reason="Adjacent" />
+    <disable_collisions link1="${prefix}gripper_base_link" link2="${prefix}gripper_jaw1_link" reason="Adjacent" />
+    <disable_collisions link1="${prefix}gripper_base_link" link2="${prefix}gripper_jaw2_link" reason="Adjacent" />
+    <disable_collisions link1="${prefix}gripper_jaw1_link" link2="${prefix}gripper_jaw2_link" reason="Default" />
+    <disable_collisions link1="${prefix}link_6" link2="${prefix}gripper_base_link" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_5" link2="${prefix}gripper_base_link" reason="Adjacent" />
   </xacro:macro>
 </robot>

--- a/annin_ar4_moveit_config/srdf/ar_macro.srdf.xacro
+++ b/annin_ar4_moveit_config/srdf/ar_macro.srdf.xacro
@@ -4,41 +4,41 @@
     A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
 -->
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-  <xacro:macro name="ar_srdf">
+  <xacro:macro name="ar_srdf" params="prefix">
     <group name="ar_manipulator">
-      <joint name="joint_1" />
-      <joint name="joint_2" />
-      <joint name="joint_3" />
-      <joint name="joint_4" />
-      <joint name="joint_5" />
-      <joint name="joint_6" />
-      <joint name="ee_joint"/>
+      <joint name="${prefix}joint_1" />
+      <joint name="${prefix}joint_2" />
+      <joint name="${prefix}joint_3" />
+      <joint name="${prefix}joint_4" />
+      <joint name="${prefix}joint_5" />
+      <joint name="${prefix}joint_6" />
+      <joint name="${prefix}ee_joint"/>
     </group>
     <group_state name="home" group="ar_manipulator">
-      <joint name="joint_1" value="0" />
-      <joint name="joint_2" value="0" />
-      <joint name="joint_3" value="0" />
-      <joint name="joint_4" value="0" />
-      <joint name="joint_5" value="0" />
-      <joint name="joint_6" value="0" />
+      <joint name="${prefix}joint_1" value="0" />
+      <joint name="${prefix}joint_2" value="0" />
+      <joint name="${prefix}joint_3" value="0" />
+      <joint name="${prefix}joint_4" value="0" />
+      <joint name="${prefix}joint_5" value="0" />
+      <joint name="${prefix}joint_6" value="0" />
     </group_state>
     <group_state name="upright" group="ar_manipulator">
-      <joint name="joint_1" value="0" />
-      <joint name="joint_2" value="-0.087" />
-      <joint name="joint_3" value="-1.4" />
-      <joint name="joint_4" value="0" />
-      <joint name="joint_5" value="0" />
-      <joint name="joint_6" value="0" />
+      <joint name="${prefix}joint_1" value="0" />
+      <joint name="${prefix}joint_2" value="-0.087" />
+      <joint name="${prefix}joint_3" value="-1.4" />
+      <joint name="${prefix}joint_4" value="0" />
+      <joint name="${prefix}joint_5" value="0" />
+      <joint name="${prefix}joint_6" value="0" />
     </group_state>
-    <disable_collisions link1="base_link" link2="link_1" reason="Adjacent" />
-    <disable_collisions link1="link_1" link2="link_2" reason="Adjacent" />
-    <disable_collisions link1="link_1" link2="link_3" reason="Never" />
-    <disable_collisions link1="link_2" link2="link_3" reason="Adjacent" />
-    <disable_collisions link1="link_3" link2="link_4" reason="Adjacent" />
-    <disable_collisions link1="link_3" link2="link_5" reason="Never" />
-    <disable_collisions link1="link_3" link2="link_6" reason="Never" />
-    <disable_collisions link1="link_4" link2="link_5" reason="Adjacent" />
-    <disable_collisions link1="link_5" link2="link_6" reason="Adjacent" />
+    <disable_collisions link1="${prefix}base_link" link2="${prefix}link_1" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_1" link2="${prefix}link_2" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_1" link2="${prefix}link_3" reason="Never" />
+    <disable_collisions link1="${prefix}link_2" link2="${prefix}link_3" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_3" link2="${prefix}link_4" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_3" link2="${prefix}link_5" reason="Never" />
+    <disable_collisions link1="${prefix}link_3" link2="${prefix}link_6" reason="Never" />
+    <disable_collisions link1="${prefix}link_4" link2="${prefix}link_5" reason="Adjacent" />
+    <disable_collisions link1="${prefix}link_5" link2="${prefix}link_6" reason="Adjacent" />
 
   </xacro:macro>
 </robot>

--- a/annin_ar4_moveit_config/urdf/fake_ar.urdf.xacro
+++ b/annin_ar4_moveit_config/urdf/fake_ar.urdf.xacro
@@ -5,14 +5,17 @@
   <xacro:include filename="$(find annin_ar4_description)/urdf/ar.ros2_control.xacro"/>
   <xacro:include filename="$(find annin_ar4_description)/urdf/ar_gripper.ros2_control.xacro"/>
 
+  <xacro:arg name="tf_prefix" default="" />
+
   <link name="world" />
   <xacro:ar_robot
+    tf_prefix="$(arg tf_prefix)"
     parent="world"
     robot_parameters_file="$(find annin_ar4_description)/config/$(arg ar_model).yaml"
   >
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:ar_robot>
-  <xacro:ar_gripper parent="ee_link" />
+  <xacro:ar_gripper parent="$(arg tf_prefix)ee_link" />
 
   <xacro:ar_ros2_control
     ar_model="$(arg ar_model)"
@@ -22,6 +25,7 @@
     robot_parameters_file="$(find annin_ar4_description)/config/$(arg ar_model).yaml"
     joint_offset_parameters_file="$(find annin_ar4_driver)/config/joint_offsets/$(arg ar_model).yaml"
     driver_parameters_file="$(find annin_ar4_driver)/config/driver.yaml"
+    tf_prefix="$(arg tf_prefix)"
   />
   <xacro:ar_gripper_ros2_control
     name="ARGripperFakeSystem"

--- a/annin_ar4_moveit_config/urdf/fake_ar.urdf.xacro
+++ b/annin_ar4_moveit_config/urdf/fake_ar.urdf.xacro
@@ -15,7 +15,10 @@
   >
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:ar_robot>
-  <xacro:ar_gripper parent="$(arg tf_prefix)ee_link" />
+  <xacro:ar_gripper 
+    tf_prefix="$(arg tf_prefix)"
+    parent="$(arg tf_prefix)ee_link" 
+  />
 
   <xacro:ar_ros2_control
     ar_model="$(arg ar_model)"
@@ -31,5 +34,6 @@
     name="ARGripperFakeSystem"
     plugin_name="mock_components/GenericSystem"
     serial_port="/dev/ttyUSB0"
+    tf_prefix="$(arg tf_prefix)"
   />
 </robot>


### PR DESCRIPTION
> [**Note**] writing the same description for clarity

I've added the option of using a tf_prefix, when launching the robot. This allows giving all the links and joints a prefix at launch, so they don't have to be set individually (see [UR ROS2 Description](https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/blob/rolling/urdf/ur_macro.xacro) for reference).

The biggest issue is how to make the .yaml files use this prefix as well. For now they need to be edited by hand. For example. running the demo as `ros2 launch annin_ar4_moveit_config demo.launch.py tf_prefix:=ar4_`, the `ar4_` prefix should also be added in

- `annin_ar4_moveit_config/config/joint_limits.yaml`, changing `joint_x` to `ar4_joint_x`
- `annin_ar4_moveit_config/config/controllers.yaml`, changing [joint_trajectory_controller][joints]`joint_x` to `ar4_joint_x`
- `annin_ar4_driver/config/controllers.yaml`, changing all `joint_x` to `ar4_joint_x`

The same applies, when running other launch files:
- `ros2 launch annin_ar4_gazebo gazebo.launch.py tf_prefix:=ar4_`
- `ros2 launch annin_ar4_moveit_config moveit.launch.py use_sim_time:=true include_gripper:=True tf_prefix:=ar4_`

Also, I think my previous comment about prepending `joint_x` in `mkx.yaml` can be disregarded, as their values are only being read in `ar.ros2_control.xacro`. Let me know what you think!