### PR TITLE
warn instead of error out when homing fails in calibration

### DIFF
--- a/annin_ar4_driver/src/teensy_driver.cpp
+++ b/annin_ar4_driver/src/teensy_driver.cpp
@@ -168,6 +168,9 @@ bool TeensyDriver::exchange(std::string outMsg) {
     if (header == "DB") {
       // debug message
       RCLCPP_DEBUG(logger_, "Debug message: %s", inMsg.c_str());
+    } else if (header == "WN") {
+      // warning message
+      RCLCPP_WARN(logger_, "Warning: %s", inMsg.c_str());
     } else {
       if (header == "ST") {
         // init acknowledgement

--- a/annin_ar4_firmware/AR4_teensy/AR4_teensy.ino
+++ b/annin_ar4_firmware/AR4_teensy/AR4_teensy.ino
@@ -488,7 +488,6 @@ bool doCalibrationRoutine(String& outputMsg) {
   }
 
   // restore original max speed
-  //
   for (int i = 0; i < NUM_JOINTS; ++i) {
     stepperJoints[i].setMaxSpeed(JOINT_MAX_SPEED[i] *
                                  MOTOR_STEPS_PER_DEG[MODEL][i]);
@@ -500,8 +499,10 @@ bool doCalibrationRoutine(String& outputMsg) {
   readMotorSteps(curMotorSteps);
   while (!AtPosition(REST_MOTOR_STEPS[MODEL], curMotorSteps, 5)) {
     if (millis() - startTime > 10000) {
-      outputMsg = "ER: Failed to return to original position.";
-      return false;
+      // print warning message
+      Serial.println(
+          "WN: Failed to return to original position post calibration.");
+      break;
     }
 
     readMotorSteps(curMotorSteps);


### PR DESCRIPTION
sometimes returning to the home position fails at the end of calibration. This is OK and the robot still works normally afterwards. 