### PR TITLE
Add support for the different ACS712 models (5A, 20A, 30A)

### DIFF
--- a/annin_ar4_description/urdf/ar_gripper.ros2_control.xacro
+++ b/annin_ar4_description/urdf/ar_gripper.ros2_control.xacro
@@ -17,6 +17,7 @@
         <plugin>${plugin_name}</plugin>
         <param name="serial_port">${serial_port}</param>
         <param name="use_overcurrent_protection">${driver_parameters['use_overcurrent_protection']}</param>
+        <param name="ACS712_version_current">${driver_parameters['ACS712_version_current']}</param>
         <param name="closed_servo_angle">${driver_parameters['closed_servo_angle']}</param>
         <param name="open_servo_angle">${driver_parameters['open_servo_angle']}</param>
         <param name="tf_prefix">${tf_prefix}</param>

--- a/annin_ar4_driver/config/gripper_driver.yaml
+++ b/annin_ar4_driver/config/gripper_driver.yaml
@@ -1,4 +1,5 @@
 use_overcurrent_protection: false
+ACS712_version_current: 5
 
 # Servo angle configuration (in degrees)
 closed_servo_angle: 0

--- a/annin_ar4_driver/include/annin_ar4_driver/arduino_nano_driver.hpp
+++ b/annin_ar4_driver/include/annin_ar4_driver/arduino_nano_driver.hpp
@@ -19,6 +19,7 @@ class ArduinoNanoDriver {
   bool getPosition(int& position);
   bool writePosition(double position);
   bool getCurrent(double& current);
+  bool writeACS712Version(int version);
 
   ArduinoNanoDriver();
 

--- a/annin_ar4_driver/src/ar_servo_gripper_hw_interface.cpp
+++ b/annin_ar4_driver/src/ar_servo_gripper_hw_interface.cpp
@@ -91,6 +91,17 @@ hardware_interface::CallbackReturn ARServoGripperHWInterface::on_activate(
     const rclcpp_lifecycle::State& /*previous_state*/) {
   RCLCPP_INFO(logger_, "Activating hardware interface...");
 
+  // Write ACS712 version if specified
+  if (overcurrent_protection_ && info_.hardware_parameters.count("ACS712_version_current") > 0) {
+    int current_version =
+        std::stoi(info_.hardware_parameters.at("ACS712_version_current"));
+    RCLCPP_INFO(logger_, "Setting ACS712 version to %dA", current_version);
+    if (!driver_.writeACS712Version(current_version)) {
+      RCLCPP_ERROR(logger_, "Failed to set ACS712 version");
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+  }
+
   // initialize gripper position
   int pos_deg;
   bool success = driver_.getPosition(pos_deg);

--- a/annin_ar4_driver/src/arduino_nano_driver.cpp
+++ b/annin_ar4_driver/src/arduino_nano_driver.cpp
@@ -132,4 +132,15 @@ bool ArduinoNanoDriver::getCurrent(double& current) {
   }
 }
 
+bool ArduinoNanoDriver::writeACS712Version(int version) {
+  std::string msg = "ACX" + std::to_string(static_cast<int>(version)) + "\n";
+  std::string reply = sendCommand(msg);
+  if (reply != "Done") {
+    RCLCPP_ERROR(logger_, "Failed to write ACS712 Version %d, got reply: %s",
+                 version, reply.c_str());
+    return false;
+  }
+  return true;
+}
+
 }  // namespace annin_ar4_driver

--- a/annin_ar4_firmware/AR4_nano/AR4_nano.ino
+++ b/annin_ar4_firmware/AR4_nano/AR4_nano.ino
@@ -66,6 +66,12 @@ const int Output11 = 11;
 const int Output12 = 12;
 const int Output13 = 13;
 
+// ACS712 models have different sensitivities
+const float ACS712_5A = 185.0;    // Sensitivity in mV/A for ACS712 5A
+const float ACS712_20A = 100.0;   // Sensitivity in mV/A for ACS712 20A
+const float ACS712_30A = 66.0;    // Sensitivity in mV/A for ACS712 30A
+float ACS712Sensitivity = ACS712_5A;  // Set default version
+
 void setup() {
   // run once:
   Serial.begin(115200);
@@ -109,9 +115,8 @@ void setup() {
 float readCurrent() {
   int sensorValue = analogRead(CurrentSensorPin);
   // Convert analog reading to current
-  // For ACS712 5A version: sensitivity is 185mV/A
   float voltage = sensorValue * (5.0 / 1024.0);
-  float current = (voltage - 2.5) / 0.185;  // 2.5V is the offset at 0A
+  float current = (voltage - 2.5) / (ACS712Sensitivity / 1000.0);  // 2.5V is the offset at 0A
   return current;
 }
 
@@ -238,6 +243,21 @@ void loop() {
       if (function == "CR") {
         float current = readCurrent();
         Serial.println(current);
+      }
+
+      //-----COMMAND TO CHANGE ACS712 VERSION/SENSITIVITY -----
+      if (function == "AC") {
+        int dataStart = inData.indexOf('X');
+        int outputNum = inData.substring(dataStart + 1).toInt();
+        if (outputNum == 20) {
+          ACS712Sensitivity = ACS712_20A;
+        } else if (outputNum == 30) {
+          ACS712Sensitivity = ACS712_30A;
+        } else {
+          // Default to 5A version
+          ACS712Sensitivity = ACS712_5A;
+        }
+        Serial.println("Done");
       }
 
       //-----COMMAND ECHO TEST MESSAGE-----

--- a/docs/gripper_overcurrent_protection.md
+++ b/docs/gripper_overcurrent_protection.md
@@ -24,5 +24,11 @@ the gripper as shown in the schematic below:
 To enable gripper overcurrent protection, set `use_overcurrent_protection` to
 `true` in the
 [gripper_driver.yaml](../annin_ar4_driver/config/gripper_driver.yaml)
-configuration file. Parameters for tuning this feature can be found in
+configuration file.
+
+The ACS712 module is available in 3 different versions: 5A, 20A, and 30A. If you have the 20A or 30A version, set `ACS712_version_current` to `20` or `30` in the
+[gripper_driver.yaml](../annin_ar4_driver/config/gripper_driver.yaml)
+configuration file.
+
+Parameters for tuning this feature can be found in
 [gripper_overcurrent_protection.hpp](../annin_ar4_driver/include/annin_ar4_driver/gripper_overcurrent_protection.hpp).


### PR DESCRIPTION
This commit adds support for setting the ACS712 model version, which each have a different current sensing mV value.

A new param has been added to `gripper_driver.yaml`. Set it to either 5, 20, or 30 to set the ACS712 version you have.

```
ACS712_version_current: 5
```

This value is sent to the arduino nano via a new control command 'AC' during the gripper interface `on_activate` process, and it always defaults to `5` if bad data is sent, or `20` or `30` is not sent.

Side note: git seems to have recreated the entire sketch file in the diff. I'm not sure why it did so 🤔. Let me know if you want the diff recreated.
