### PR TITLE
Update docker config so that ros2 commands can be run directly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**install
+**build
+**log
+docker/Dockerfile

--- a/README.md
+++ b/README.md
@@ -94,13 +94,26 @@ A docker container and run script has been provided that can be used to run the
 robot and any GUI programs. It requires [rocker](https://github.com/osrf/rocker) to be installed. Then you can start the docker container with:
 
 ```bash
-docker build -t ar4_ros_driver .
+docker build -t ar4_ros_driver -f docker/Dockerfile .
 
 # Adjust the volume mounting and devices based on your project and hardware
 rocker --ssh --x11 \
   --devices /dev/ttyUSB0 /dev/ttyACM0 \
-  --volume $(pwd):/ar4_ws/src/ar4_ros_driver -- \
+  --volume $(pwd):/ar4_ws/src -- \
   ar4_ros_driver bash
+```
+
+The docker image runs colcon build during the docker image build process, and will source the `setup.bash` file when the container starts (see `docker/entrypoint.sh`).
+Therefor the image can be used to directly run ros2 commands.
+
+For example, to run the annin_ar4_driver node directly:
+
+```bash
+rocker --ssh --x11 \
+  --devices /dev/ttyUSB0 /dev/ttyACM0 \
+  --volume $(pwd):/ar4_ws/src -- \
+  ar4_ros_driver \
+  ros2 launch annin_ar4_driver driver.launch.py calibrate:=True ar_model:="mk2"
 ```
 
 ## Usage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM ros:jazzy
+
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /ar4_ws
+COPY . /ar4_ws/src
+
+RUN apt update
+RUN rosdep update
+RUN rosdep install --from-paths src --ignore-src -r -y
+
+RUN source /opt/ros/jazzy/setup.bash && colcon build --symlink-install
+
+COPY ./docker/entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+source /ar4_ws/install/setup.bash
+
+exec "$@"


### PR DESCRIPTION
This PR updates the way the docker image is built to enable directly running ros2 commands when starting the container, such as running the ar4 driver, while still enabling the use of the docker image for development.

The following changes have been made:

- The source code is copied from the local filesystem rather than the github remote, which enables local changes to be baked into the docker image by simply running `docker build` again. I think it's safe to assume the user has already cloned the codebase if they are building the docker image.
- `colcon build` is run during the docker build process, so that it does not need to be manually run each time the container is started.
- The docker image starts via the `entrypoint.sh` file, which simply sources `install.bash`, enabling `ros2` commands for the project's launch files etc to be passed directly to the container when starting.
- `colcon build` is run with `--symlink-install`, which enables the user to mount their local copy of the codebase into the container and make live changes to python files without needing to rebuild the container.
- `colcon build --symlink-install`, `source ./install/setup.bash` can still be re-run without needing to stop and rebuild the container. E.g. if new files are added by the user and they have their local copy mounted in.

I've also updated the README accordingly to note some of these changes, but let me know if you think it needs more. 

One final thing to note is that the project code lives in the container at `/ar4_ws/src`, however the docker `WORKDIR` is set to the parent dir `/ar4_ws`. This is intentionally so that the colcon build artifacts (`build`, `install`, `log`) are separate to the main code, and not overridden in the case the user mounts their local files onto `/ar4_ws/src`. This does have the downside that colcon rebuilds during a container session will not be persisted, but I think it's a safer/more predictable tradeoff than the alternative of having them inside `/ar4_ws/src`. The user can always simply rebuild the container, which will pick up their local changes and update the colcon artifacts accordingly. 